### PR TITLE
feat(v20260420j): LP調整 + HTML 真実化 5スライス（違反色 / Hero書体 / Footer SoT / キャッシュバスター / 割れトークン除去）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ test-results/
 
 # Icons backup
 icons/backup/
+
+# Staging workspace (preview only, not deployed)
+_workspace/
+
+# OS
+.DS_Store

--- a/assets/css/renewal.css
+++ b/assets/css/renewal.css
@@ -975,5 +975,144 @@ section#flow .grid > .text-center .rounded-full.bg-brand-blue {
   .hero-followup-lede { font-size: clamp(1.125rem, 1.4vw, 1.375rem) !important; }
 }
 
+/* =========================================================
+   v20260421 サイズ感調整（cursorvers.jp と同程度の密度に）
+   - Hero 1行目「AIに、臨床の魂を」を一段小さく
+   - 主要見出しとリード段落を ~15% スケールダウン
+   ========================================================= */
+.hero-motion-brush,
+.hero-motion-brush .hero-motion-token {
+  font-size: clamp(3.25rem, 9.5vw, 7.5rem) !important;   /* was clamp(3.75rem, 11vw, 9rem) */
+  line-height: 1.08 !important;
+}
+
+.hero-motion-title {
+  font-size: clamp(2.5rem, 7.2vw, 5.75rem) !important;   /* was clamp(2.75rem, 8.2vw, 6.75rem) */
+}
+
+.hero-motion-title .hero-motion-subline,
+.hero-motion-title .hero-subline {
+  font-size: clamp(1.375rem, 2.6vw, 2.125rem) !important;    /* was clamp(1.5rem, 3vw, 2.5rem) */
+}
+
+.hero-content h1.text-display,
+h1.text-display {
+  font-size: clamp(2.5rem, 6.2vw, 4.25rem) !important;
+  line-height: 1.1 !important;
+}
+
+.hero-followup-heading {
+  font-size: clamp(1.5rem, 3.2vw, 2.5rem) !important;   /* was clamp(1.625rem, 3.6vw, 2.75rem) */
+}
+@media (min-width: 1280px) {
+  .hero-followup-heading {
+    font-size: clamp(1.75rem, 2.4vw, 2.625rem) !important;   /* was clamp(2rem, 2.6vw, 3rem) */
+  }
+}
+.hero-followup-lede {
+  font-size: clamp(0.9375rem, 1.4vw, 1.125rem) !important;   /* was clamp(1rem, 1.6vw, 1.25rem) */
+}
+@media (min-width: 1024px) {
+  .hero-followup-lede { font-size: clamp(1rem, 1.2vw, 1.1875rem) !important; }
+}
+
+/* ==========================================================================
+   v20260421 News cards v2 (visual-first)
+   絵のある上段ビジュアル + 本文のプレスカード型
+   ========================================================================== */
+.news-scroll-v2 { gap: 1.25rem; }
+.news-card-v2 {
+  scroll-snap-align: start;
+  flex: 0 0 auto;
+  width: clamp(260px, 78vw, 320px);
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  overflow: hidden;
+  transition: border-color .25s ease, box-shadow .25s ease, transform .25s ease;
+}
+@media (min-width: 768px) { .news-card-v2 { width: 320px; } }
+.news-card-v2:hover {
+  border-color: rgba(229, 88, 18, 0.28);
+  box-shadow: 0 10px 30px -12px rgba(17, 24, 39, 0.18);
+  transform: translateY(-2px);
+}
+.news-card-v2-link { display: block; color: inherit; text-decoration: none; }
+.news-card-v2-visual {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  display: flex; align-items: center; justify-content: center;
+  overflow: hidden;
+  border-bottom: 1px solid #f3f4f6;
+}
+.news-card-v2-visual > .news-visual-lockup,
+.news-card-v2-visual > .news-visual-caption {
+  position: relative;
+  z-index: 1;
+}
+.news-card-v2-body { padding: 18px 18px 20px; }
+.news-card-v2-meta { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+.news-card-v2-tag {
+  display: inline-block;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+  padding: 4px 10px; border-radius: 3px; color: #fff; line-height: 1.4;
+}
+.news-tag-flame   { background: #E55812; }
+.news-tag-navy    { background: #1f2937; }
+.news-tag-emerald { background: #047857; }
+.news-card-v2-date {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 12px; color: #9ca3af; letter-spacing: 0.02em;
+}
+.news-card-v2-title {
+  font-size: 15px; font-weight: 700; color: #1d1d1f;
+  line-height: 1.55; margin: 0 0 8px;
+  display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
+}
+@media (min-width: 768px) { .news-card-v2-title { font-size: 16px; } }
+.news-card-v2-lede {
+  font-size: 12.5px; color: #6b7280; line-height: 1.7; margin: 0 0 12px;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.news-card-v2-cta {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12.5px; font-weight: 700; color: #E55812;
+}
+.news-card-v2-cta svg { transition: transform .25s ease; }
+.news-card-v2:hover .news-card-v2-cta svg { transform: translateX(3px); }
+
+/* Visual variants */
+.news-visual-caption {
+  font-size: 11.5px; color: rgba(255,255,255,0.72); letter-spacing: 0.02em;
+}
+
+.news-visual-lockup-card {
+  background: #ffffff;
+  display: flex; flex-direction: column; gap: 10px; padding: 18px 22px;
+  align-items: center; justify-content: center;
+}
+.news-visual-lockup-card--emerald {
+  background: #ffffff;
+}
+.news-visual-lockup { display: flex; align-items: center; justify-content: center; gap: 12px; width: 100%; }
+.news-visual-lockup--solo { justify-content: center; }
+.news-visual-brand {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 12px; font-weight: 800; letter-spacing: 0.08em; color: #1d1d1f;
+  padding: 8px 12px; border-radius: 6px; background: #fff; border: 1px solid #e5e7eb;
+  text-transform: uppercase; white-space: nowrap;
+}
+.news-visual-wordmark {
+  font-family: "Helvetica Neue", system-ui, sans-serif;
+  font-size: 15px; font-weight: 800; letter-spacing: 0.02em;
+  padding: 8px 12px; border-radius: 6px;
+  background: #fff; border: 1px solid #e5e7eb;
+  white-space: nowrap;
+}
+.news-visual-wordmark--flame { color: #E55812; }
+.news-visual-x { color: #E55812; font-weight: 800; font-size: 18px; }
+.news-visual-logo { max-height: 32px; max-width: 130px; object-fit: contain; }
+.news-visual-lockup-card .news-visual-caption { color: #6b7280; font-size: 11px; letter-spacing: 0.06em; }
+
 /* End */
 

--- a/assets/css/renewal.css
+++ b/assets/css/renewal.css
@@ -70,11 +70,11 @@ a:focus-visible, button:focus-visible, input:focus-visible, summary:focus-visibl
 
 /* ---- Typography ---- */
 .hero-h1 {
-  font-family: var(--font-sans);
+  font-family: "Zen Old Mincho", "Noto Serif JP", serif;
   font-size: clamp(2rem, 4vw + 1rem, 3.25rem);
-  line-height: 1.2;
+  line-height: 1.25;
   font-weight: 900;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.01em;
   color: var(--c-text);
   margin-bottom: 1.5rem;
 }
@@ -619,7 +619,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, summary:focus-visibl
 .hero-subline, .hero-motion-subline { color: var(--c-flame) !important; }
 
 /* Hero main title accent override (stronger weight via font stack) */
-.hero-motion-title { font-family: var(--font-sans) !important; color: var(--c-slate-900) !important; }
+.hero-motion-title { font-family: "Zen Old Mincho", "Noto Serif JP", serif !important; font-weight: 900 !important; color: var(--c-slate-900) !important; }
 
 /* Badges / pills with legacy brand-blue */
 .border-brand-blue\/20 { border-color: rgba(255,69,0,.25) !important; }

--- a/consulting.html
+++ b/consulting.html
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     
     <style>

--- a/consulting.html
+++ b/consulting.html
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     
     <style>

--- a/consulting.html
+++ b/consulting.html
@@ -422,6 +422,10 @@
                         <svg class="text-flame mr-2" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-check"></use></svg>
                         レビュー後のライト顧問
                     </p>
+                    <p class="text-xl font-bold text-flame mt-3 mb-2">
+                        目安 15〜30万円/月(税別)／3か月〜
+                        <span class="block text-sm text-text-tertiary font-normal mt-1">スコープ・面談頻度により個別設計</span>
+                    </p>
                     <p class="text-lg text-text-secondary">
                         スポットレビュー後に必要な場合のみ、月2回30分の定例相談とQ&A対応を、範囲を切って別途設計します。
                     </p>

--- a/consulting.html
+++ b/consulting.html
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     
     <style>

--- a/consulting.html
+++ b/consulting.html
@@ -532,53 +532,46 @@
     </main>
 
     <!-- Footer (same as index.html) -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture><source srcset="Cursorvers_logo_white.webp" type="image/webp"><img src="Cursorvers_logo_white.jpeg" onerror="this.style.display='none'"
-                            alt="Cursorvers inverted logomark" class="h-10 w-10 rounded-full border border-white/20"></picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関</p>
-                </div>
-                <div class="flex gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="news.html" class="hover:text-white transition">お知らせ</a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div
-                class="mt-20 pt-10 border-t border-gray-800 flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <div class="flex gap-6 text-xl">
-                    <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                        target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                        <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-linkedin"></use></svg>
-                    </a>
-                </div>
-            </div>
-            <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script>

--- a/consulting.html
+++ b/consulting.html
@@ -234,7 +234,7 @@
 
             <div class="relative z-10 max-w-4xl mx-auto">
                 <p class="text-lg font-semibold text-flame mb-4 font-en">医療AIベンダー向け</p>
-                <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
+                <h1 class="hero-h1 text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
                     病院に届く提案へ<br><span class="gradient-text">臨床目線で磨き込む</span>
                 </h1>
                 <p class="text-xl md:text-2xl text-text-secondary max-w-2xl mx-auto mb-10 leading-relaxed text-balance">

--- a/contact.html
+++ b/contact.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <style>

--- a/contact.html
+++ b/contact.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <style>
@@ -263,7 +263,7 @@
                         target="_blank" rel="noopener noreferrer"
                         class="bg-white rounded-2xl p-8 card-hover flex flex-col text-center group"
                         onclick="if(window.gtag)gtag('event','contact_click',{label:'vendor'})">
-                        <div class="w-20 h-20 bg-slate-50 rounded-full flex items-center justify-center mx-auto mb-6 group-hover:bg-brand-cyan transition">
+                        <div class="w-20 h-20 bg-slate-50 rounded-full flex items-center justify-center mx-auto mb-6 group-hover:bg-flame/10 transition">
                             <svg class="text-3xl text-slate-600 group-hover:text-brand-black transition" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-microchip"></use></svg>
                         </div>
                         <h3 class="text-2xl font-bold mb-4">AIベンダーの方</h3>

--- a/contact.html
+++ b/contact.html
@@ -263,8 +263,8 @@
                         target="_blank" rel="noopener noreferrer"
                         class="bg-white rounded-2xl p-8 card-hover flex flex-col text-center group"
                         onclick="if(window.gtag)gtag('event','contact_click',{label:'vendor'})">
-                        <div class="w-20 h-20 bg-cyan-50 rounded-full flex items-center justify-center mx-auto mb-6 group-hover:bg-brand-cyan transition">
-                            <svg class="text-3xl text-cyan-600 group-hover:text-brand-black transition" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-microchip"></use></svg>
+                        <div class="w-20 h-20 bg-slate-50 rounded-full flex items-center justify-center mx-auto mb-6 group-hover:bg-brand-cyan transition">
+                            <svg class="text-3xl text-slate-600 group-hover:text-brand-black transition" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-microchip"></use></svg>
                         </div>
                         <h3 class="text-2xl font-bold mb-4">AIベンダーの方</h3>
                         <p class="text-lg text-text-secondary mb-6 leading-relaxed flex-1">
@@ -272,19 +272,19 @@
                         </p>
                         <ul class="text-left text-text-tertiary mb-6 space-y-2">
                             <li class="flex items-center gap-2 text-sm">
-                                <svg class="text-cyan-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-check"></use></svg>
+                                <svg class="text-slate-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-check"></use></svg>
                                 市場参入支援
                             </li>
                             <li class="flex items-center gap-2 text-sm">
-                                <svg class="text-cyan-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-check"></use></svg>
+                                <svg class="text-slate-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-check"></use></svg>
                                 ガイドライン対応
                             </li>
                             <li class="flex items-center gap-2 text-sm">
-                                <svg class="text-cyan-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-check"></use></svg>
+                                <svg class="text-slate-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-check"></use></svg>
                                 品質保証体制構築
                             </li>
                             <li class="flex items-center gap-2 text-sm">
-                                <svg class="text-cyan-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-check"></use></svg>
+                                <svg class="text-slate-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-check"></use></svg>
                                 導入支援
                             </li>
                         </ul>

--- a/contact.html
+++ b/contact.html
@@ -191,7 +191,7 @@
         <section class="py-20 md:py-28 px-6 bg-brand-gray">
             <div class="max-w-4xl mx-auto text-center">
                 <span class="pill-eyebrow" style="display:inline-flex; margin-bottom:1.5rem;"><span class="pill-eyebrow__dot"></span>Contact / お問い合わせ</span>
-                <h1 class="text-4xl md:text-5xl font-bold tracking-tight mb-6">
+                <h1 class="hero-h1 text-4xl md:text-5xl font-bold tracking-tight mb-6">
                     医療AIの<span style="color:var(--c-flame);">提案前レビュー</span>・<br class="hidden md:block">セカンドオピニオン、まずは無料相談から。
                 </h1>
                 <hr class="section-divider--flame" style="margin:0 auto 1.5rem;">

--- a/contact.html
+++ b/contact.html
@@ -361,52 +361,46 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture><source srcset="Cursorvers_logo_white.webp" type="image/webp"><img src="Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers"
-                            class="h-10 w-10 rounded-full border border-white/20"></picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">医療AIの"産業医" — 提案前に、責任分界を整える</p>
-                </div>
-                <div class="flex gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="news.html" class="hover:text-white transition">お知らせ</a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div
-                class="mt-20 pt-10 border-t border-gray-800 flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <div class="flex gap-6 text-xl">
-                    <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                        target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                        <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-                    </a>
-                </div>
-            </div>
-            <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script>

--- a/contact.html
+++ b/contact.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <style>

--- a/gov-lead.html
+++ b/gov-lead.html
@@ -64,7 +64,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/gov-lead.html
+++ b/gov-lead.html
@@ -358,8 +358,8 @@
                         </p>
                     </div>
                     <div class="bg-white rounded-2xl p-8 card-hover">
-                        <div class="w-16 h-16 bg-cyan-50 rounded-xl flex items-center justify-center mb-6">
-                            <svg class="text-3xl text-cyan-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-clipboard-check"></use></svg>
+                        <div class="w-16 h-16 bg-slate-50 rounded-xl flex items-center justify-center mb-6">
+                            <svg class="text-3xl text-slate-600" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-clipboard-check"></use></svg>
                         </div>
                         <h3 class="text-2xl font-bold mb-4">評価と教育</h3>
                         <p class="text-lg md:text-xl text-text-secondary leading-relaxed">

--- a/gov-lead.html
+++ b/gov-lead.html
@@ -1014,41 +1014,46 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-16 border-t border-gray-800">
-        <div class="max-w-7xl mx-auto px-6">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-12">
-                <div>
-                    <div class="flex items-center gap-3 mb-4">
-                        <picture><source srcset="Cursorvers_logo_white.webp" type="image/webp"><img src="Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers" class="h-10 w-10 rounded-full border border-white/20" loading="lazy"></picture>
-                        <span class="text-xl font-bold font-en tracking-widest">Cursorvers</span>
-                    </div>
-                    <p class="text-gray-400">医療AIの"産業医" — 提案前に、責任分界を整える</p>
-                </div>
-                <div class="flex gap-12">
-                    <div>
-                        <h3 class="font-bold mb-4">リンク</h3>
-                        <ul class="space-y-3 text-gray-400">
-                            <li><a href="services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="news.html" class="hover:text-white transition">お知らせ</a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="font-bold mb-4">法的情報</h3>
-                        <ul class="space-y-3 text-gray-400">
-                            <li><a href="privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="mt-12 pt-8 border-t border-gray-800 text-center text-gray-500 text-sm font-en">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <p class="mt-2 text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-            </div>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script>

--- a/gov-lead.html
+++ b/gov-lead.html
@@ -64,7 +64,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/gov-lead.html
+++ b/gov-lead.html
@@ -64,7 +64,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>
@@ -425,7 +425,7 @@
                     </div>
                 </div>
 
-                <div id="check-result" class="hidden bg-gradient-to-r from-flame/10 to-brand-cyan/10 rounded-2xl p-8 text-center">
+                <div id="check-result" class="hidden bg-gradient-to-r from-flame/10 to-navy/10 rounded-2xl p-8 text-center">
                     <p id="result-text" class="text-xl md:text-2xl font-medium text-brand-black mb-6"></p>
                     <div class="flex flex-col sm:flex-row gap-4 justify-center">
                         <a href="contact.html"
@@ -998,7 +998,7 @@
 
                 <div class="flex flex-col sm:flex-row gap-4 justify-center mb-10">
                     <a href="contact.html"
-                        class="inline-flex items-center justify-center px-12 py-5 sm:min-w-[280px] bg-white text-brand-black font-bold text-xl rounded-full hover:bg-brand-cyan transition cta-balanced"
+                        class="inline-flex items-center justify-center px-12 py-5 sm:min-w-[280px] bg-white text-brand-black font-bold text-xl rounded-full hover:bg-flame hover:text-white transition cta-balanced"
                         onclick="if(window.gtag)gtag('event','cta_click',{label:'govlead_final_consult'})">
                         無料で相談する <svg class="" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-arrow-right"></use></svg>
                     </a>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&family=Zen+Old+Mincho:wght@700;900&family=Kaisei+Tokumin:wght@700;800&family=Shippori+Antique+B1&family=New+Tegomin&family=Noto+Serif+JP:wght@700;900&family=Yuji+Mai&family=Yuji+Syuku&family=Klee+One:wght@600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     <style>
         body { font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif; font-feature-settings: "palt"; background: #fff; color: #0F172A; }
@@ -866,7 +866,7 @@
 
             <div class="mobile-proof-grid mt-12 md:mt-16 pt-8 border-t border-gray-200 grid sm:grid-cols-3 gap-6 md:gap-10">
                 <div>
-                    <p class="proof-metric text-flame text-4xl md:text-5xl leading-none"><span class="proof-metric-unit mr-1">約</span>２０<span class="proof-metric-unit ml-1">年</span></p>
+                    <p class="text-flame font-bold text-4xl md:text-5xl leading-none">約20年</p>
                     <p class="mt-3 text-sm md:text-base text-text-secondary leading-relaxed">医療現場の運用経験を、AI導入判断に接続します。</p>
                 </div>
                 <div>
@@ -896,116 +896,124 @@
                 </a>
             </div>
 
-            <!-- News Items (horizontal scroll rail) -->
+            <!-- News Items (horizontal scroll rail, visual-first cards) -->
             <div class="news-scroll-wrapper">
-            <div class="news-scroll" id="newsScroll" tabindex="0" aria-label="お知らせ一覧。横にスクロールしてすべての記事を閲覧できます。">
+            <div class="news-scroll news-scroll-v2" id="newsScroll" tabindex="0" aria-label="お知らせ一覧。横にスクロールしてすべての記事を閲覧できます。">
                 <!-- 医療AI導入の順番 -->
-                <article class="group bg-white rounded-xl border border-gray-200 p-5 md:p-6 hover:border-flame/20 hover:shadow-md transition-all duration-300">
-                    <div class="flex flex-col md:flex-row md:items-start md:gap-5">
-                        <div class="flex-1 min-w-0">
-                            <div class="flex flex-wrap items-center gap-3 mb-3">
-                                <span class="inline-flex items-center gap-1.5 bg-navy/10 text-navy text-xs font-bold px-3 py-1 rounded-full">
-                                    <span class="w-1.5 h-1.5 rounded-full bg-navy"></span>
-                                    コラム
-                                </span>
-                                <time datetime="2026-03-02" class="text-sm text-gray-400 font-en">2026.03.02</time>
+                <article class="news-card-v2 group">
+                    <a href="news/2026-03-02-hospital-ai-implementation.html" class="news-card-v2-link">
+                        <div class="news-card-v2-visual news-visual-lockup-card" aria-label="Cursorvers Column">
+                            <div class="news-visual-lockup news-visual-lockup--solo">
+                                <span class="news-visual-brand">Cursorvers</span>
                             </div>
-                            <h3 class="text-lg md:text-xl font-bold text-brand-black mb-2 leading-snug">
+                            <span class="news-visual-caption">内科医 × エンジニア 共同執筆</span>
+                        </div>
+                        <div class="news-card-v2-body">
+                            <div class="news-card-v2-meta">
+                                <span class="news-card-v2-tag news-tag-navy">コラム</span>
+                                <time datetime="2026-03-02" class="news-card-v2-date">2026.03.02</time>
+                            </div>
+                            <h3 class="news-card-v2-title">
                                 「病院AI導入には順番がある」— 内科医×エンジニアが示す実装の地図
                             </h3>
-                            <p class="text-sm text-text-secondary leading-relaxed mb-3">
-                                松尾研AI経営講座を受講した内科医が整理した、病院AI導入の3つのフレームワーク。Cursorversのガバナンス支援との接点を解説します。
+                            <p class="news-card-v2-lede">
+                                松尾研AI経営講座を受講した内科医が整理した、病院AI導入の3つのフレームワーク。
                             </p>
-                            <a href="news/2026-03-02-hospital-ai-implementation.html" class="inline-flex items-center gap-2 text-flame hover:text-brand-black text-sm font-bold transition-colors group/link">
+                            <span class="news-card-v2-cta">
                                 詳しく読む
-                                <svg class="group-hover/link:translate-x-1 transition-transform" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-                            </a>
+                                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+                            </span>
                         </div>
-                    </div>
+                    </a>
                 </article>
 
                 <!-- Health ISAC Japan -->
-                <article class="group bg-white rounded-xl border border-gray-200 p-5 md:p-6 hover:border-flame/20 hover:shadow-md transition-all duration-300">
-                    <div class="flex flex-col md:flex-row md:items-start md:gap-5">
-                        <div class="flex-1 min-w-0">
-                            <div class="flex flex-wrap items-center gap-3 mb-3">
-                                <span class="inline-flex items-center gap-1.5 bg-flame/10 text-flame text-xs font-bold px-3 py-1 rounded-full">
-                                    <span class="w-1.5 h-1.5 rounded-full bg-flame"></span>
-                                    セキュリティ
-                                </span>
-                                <time datetime="2026-02-18" class="text-sm text-gray-400 font-en">2026.02.18</time>
+                <article class="news-card-v2 group">
+                    <a href="news/2026-02-18-health-isac-japan.html" class="news-card-v2-link">
+                        <div class="news-card-v2-visual news-visual-lockup-card" aria-label="Cursorvers × Health ISAC Japan">
+                            <div class="news-visual-lockup">
+                                <span class="news-visual-brand">Cursorvers</span>
+                                <span class="news-visual-x" aria-hidden="true">×</span>
+                                <img src="images/logo-health-isac-japan.png" alt="Health ISAC Japan logo" class="news-visual-logo" loading="lazy">
                             </div>
-                            <h3 class="text-lg md:text-xl font-bold text-brand-black mb-2 leading-snug">
+                            <span class="news-visual-caption">医療サイバーセキュリティ協賛会員</span>
+                        </div>
+                        <div class="news-card-v2-body">
+                            <div class="news-card-v2-meta">
+                                <span class="news-card-v2-tag news-tag-flame">セキュリティ</span>
+                                <time datetime="2026-02-18" class="news-card-v2-date">2026.02.18</time>
+                            </div>
+                            <h3 class="news-card-v2-title">
                                 Health ISAC Japan の協賛会員として登録されました
                             </h3>
-                            <p class="text-sm text-text-secondary leading-relaxed mb-3">
-                                医療サイバーセキュリティの情報共有組織に参加し、ガバナンス支援をセキュリティの側面からも強化します。
+                            <p class="news-card-v2-lede">
+                                医療サイバーセキュリティの情報共有組織に参加し、ガバナンス支援を強化します。
                             </p>
-                            <a href="news/2026-02-18-health-isac-japan.html" class="inline-flex items-center gap-2 text-flame hover:text-brand-black text-sm font-bold transition-colors group/link">
+                            <span class="news-card-v2-cta">
                                 詳しく読む
-                                <svg class="group-hover/link:translate-x-1 transition-transform" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-                            </a>
+                                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+                            </span>
                         </div>
-                        <div class="news-logo-lockup shrink-0 hidden md:flex bg-white rounded-lg px-4 py-3 border border-gray-100 shadow-sm items-center justify-center self-center gap-3" aria-label="Cursorvers と Health ISAC Japan">
-                            <span class="flex h-12 w-28 items-center justify-center rounded-md bg-slate-50 px-3 font-en text-xs font-bold tracking-wide text-brand-charcoal uppercase" aria-label="Cursorvers">Cursorvers</span>
-                            <span class="text-flame text-xl font-bold" aria-hidden="true">×</span>
-                            <a href="https://health-isac-japan.jp/" target="_blank" rel="noopener noreferrer" class="flex h-12 w-28 items-center justify-center hover:opacity-80 transition-opacity">
-                                <img src="images/logo-health-isac-japan.png" alt="Health ISAC Japan logo" class="max-h-10 max-w-28 object-contain" loading="lazy">
-                            </a>
-                        </div>
-                    </div>
+                    </a>
                 </article>
 
                 <!-- G-gen Partnership -->
-                <article class="group bg-white rounded-xl border border-gray-200 p-5 md:p-6 hover:border-flame/20 hover:shadow-md transition-all duration-300">
-                    <div class="flex flex-col md:flex-row md:items-start md:gap-5">
-                        <div class="flex-1 min-w-0">
-                            <div class="flex flex-wrap items-center gap-3 mb-3">
-                                <span class="inline-flex items-center gap-1.5 bg-emerald-50 text-emerald-700 text-xs font-bold px-3 py-1 rounded-full">
-                                    <span class="w-1.5 h-1.5 rounded-full bg-emerald-600"></span>
-                                    パートナーシップ
-                                </span>
-                                <time datetime="2026-02-16" class="text-sm text-gray-400 font-en">2026.02.16</time>
+                <article class="news-card-v2 group">
+                    <a href="news/2026-02-16-ggen-partnership.html" class="news-card-v2-link">
+                        <div class="news-card-v2-visual news-visual-lockup-card news-visual-lockup-card--emerald" aria-label="Cursorvers × G-gen">
+                            <div class="news-visual-lockup">
+                                <span class="news-visual-brand">Cursorvers</span>
+                                <span class="news-visual-x" aria-hidden="true">×</span>
+                                <img src="images/logo-ggen.png" alt="G-gen logo" class="news-visual-logo" loading="lazy">
                             </div>
-                            <h3 class="text-lg md:text-xl font-bold text-brand-black mb-2 leading-snug">
-                                Google Cloud プレミアパートナー<br class="hidden md:inline"> 株式会社G-gen とパートナーシップを締結
+                            <span class="news-visual-caption">Google Cloud Premier Partner 協業</span>
+                        </div>
+                        <div class="news-card-v2-body">
+                            <div class="news-card-v2-meta">
+                                <span class="news-card-v2-tag news-tag-emerald">パートナーシップ</span>
+                                <time datetime="2026-02-16" class="news-card-v2-date">2026.02.16</time>
+                            </div>
+                            <h3 class="news-card-v2-title">
+                                Google Cloud プレミアパートナー 株式会社G-gen とパートナーシップを締結
                             </h3>
-                            <p class="text-sm text-text-secondary leading-relaxed mb-3">
+                            <p class="news-card-v2-lede">
                                 Googleプロダクトを活用した「安心・安全」な医療AI環境の構築を共同で推進します。
                             </p>
-                            <a href="news/2026-02-16-ggen-partnership.html" class="inline-flex items-center gap-2 text-flame hover:text-brand-black text-sm font-bold transition-colors group/link">
+                            <span class="news-card-v2-cta">
                                 詳しく読む
-                                <svg class="group-hover/link:translate-x-1 transition-transform" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-                            </a>
+                                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+                            </span>
                         </div>
-                        <div class="news-logo-lockup shrink-0 hidden md:flex bg-white rounded-lg px-4 py-3 border border-gray-100 shadow-sm items-center justify-center self-center gap-3" aria-label="Cursorvers と G-gen">
-                            <span class="flex h-12 w-28 items-center justify-center rounded-md bg-slate-50 px-3 font-en text-xs font-bold tracking-wide text-brand-charcoal uppercase" aria-label="Cursorvers">Cursorvers</span>
-                            <span class="text-flame text-xl font-bold" aria-hidden="true">×</span>
-                            <a href="https://g-gen.co.jp/" target="_blank" rel="noopener noreferrer" class="flex h-12 w-28 items-center justify-center hover:opacity-80 transition-opacity">
-                                <img src="images/logo-ggen.png" alt="G-gen logo" class="max-h-10 max-w-28 object-contain" loading="lazy">
-                            </a>
-                        </div>
-                    </div>
+                    </a>
                 </article>
 
                 <!-- GuideScope -->
-                <article class="group bg-white rounded-xl border border-gray-200 p-6 hover:border-flame/20 hover:shadow-md transition-all duration-300">
-                    <div class="flex flex-wrap items-center gap-3 mb-3">
-                        <span class="inline-flex items-center gap-1.5 bg-flame/8 text-flame text-xs font-bold px-3 py-1 rounded-full">
-                            <span class="w-1.5 h-1.5 rounded-full bg-flame"></span>
-                            プロダクト
-                        </span>
-                        <time datetime="2026-02-10" class="text-sm text-gray-400 font-en">2026.02.10</time>
-                    </div>
-                    <h3 class="text-lg md:text-xl font-bold text-brand-black mb-2 leading-snug">
-                        GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ
-                    </h3>
-                    <p class="text-sm text-text-secondary leading-relaxed mb-3">
-                        院内マニュアルのGL準拠確認とシステム契約チェックを中核に、段階的に対応領域を拡大します。
-                    </p>
-                    <a href="news/2026-02-10-guidescope.html" class="inline-flex items-center gap-2 text-flame hover:text-brand-black text-sm font-bold transition-colors group/link">
-                        詳しく読む
-                        <svg class="group-hover/link:translate-x-1 transition-transform" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+                <article class="news-card-v2 group">
+                    <a href="news/2026-02-10-guidescope.html" class="news-card-v2-link">
+                        <div class="news-card-v2-visual news-visual-lockup-card" aria-label="Cursorvers × GuideScope">
+                            <div class="news-visual-lockup">
+                                <span class="news-visual-brand">Cursorvers</span>
+                                <span class="news-visual-x" aria-hidden="true">×</span>
+                                <span class="news-visual-wordmark news-visual-wordmark--flame">GuideScope</span>
+                            </div>
+                            <span class="news-visual-caption">自社プロダクト 開発中</span>
+                        </div>
+                        <div class="news-card-v2-body">
+                            <div class="news-card-v2-meta">
+                                <span class="news-card-v2-tag news-tag-flame">プロダクト</span>
+                                <time datetime="2026-02-10" class="news-card-v2-date">2026.02.10</time>
+                            </div>
+                            <h3 class="news-card-v2-title">
+                                GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ
+                            </h3>
+                            <p class="news-card-v2-lede">
+                                院内マニュアルのGL準拠確認とシステム契約チェックを中核に、段階的に対応領域を拡大します。
+                            </p>
+                            <span class="news-card-v2-cta">
+                                詳しく読む
+                                <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+                            </span>
+                        </div>
                     </a>
                 </article>
             </div>
@@ -1021,7 +1029,7 @@
             <div class="grid md:grid-cols-[0.92fr_1.08fr] gap-8 md:gap-14 lg:gap-16 items-center">
                 <div>
                     <span class="text-flame text-xs font-bold tracking-[0.18em] block mb-3">名称の由来</span>
-                    <h2 class="font-bold text-brand-black text-2xl md:text-4xl leading-tight text-balance">「Cursorvers」という社名に込めたもの</h2>
+                    <h2 class="font-bold text-brand-black text-2xl md:text-4xl leading-tight text-balance" style="word-break: keep-all; overflow-wrap: break-word;"><span class="whitespace-nowrap">「Cursorvers」という</span><span class="whitespace-nowrap">社名に込めたもの</span></h2>
                     <p class="text-text-secondary text-sm md:text-base leading-relaxed mt-4">
                         Cursorvers（カーソルバース）は、Cursor（判断点）とvers（turn＝向きを変える）を掛け合わせた造語です。
                     </p>
@@ -1065,7 +1073,7 @@
                     <h2 class="text-3xl md:text-4xl font-bold text-brand-black">2つの入口</h2>
                 </div>
                 <p class="text-sm md:text-base text-text-secondary leading-relaxed max-w-xl">
-                    医療機関には導入判断と監査観点を。医療AIベンダーには病院に届く説明責任の整理を返します。
+                    医療機関には導入判断と監査観点を。<br>医療AIベンダーには病院に届く説明責任の整理を返します。
                 </p>
             </div>
 
@@ -1107,6 +1115,9 @@
                     <h3 class="text-2xl md:text-3xl font-bold text-brand-black mb-5">病院提案の前に、懸念点を言語化する。</h3>
                     <p class="text-text-secondary text-base md:text-lg leading-relaxed flex-grow">
                         提案書・責任分界・院内説明を、医療機関の稟議と現場運用の観点で赤入れします。
+                    </p>
+                    <p class="text-xs md:text-sm text-text-tertiary mt-3 mb-0 leading-snug">
+                        スポット 18万円〜／ライト顧問 15〜30万円/月(税別)
                     </p>
 
                     <div class="space-y-3 mt-7">

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&family=Zen+Old+Mincho:wght@700;900&family=Kaisei+Tokumin:wght@700;800&family=Shippori+Antique+B1&family=New+Tegomin&family=Noto+Serif+JP:wght@700;900&family=Yuji+Mai&family=Yuji+Syuku&family=Klee+One:wght@600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     <style>
         body { font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif; font-feature-settings: "palt"; background: #fff; color: #0F172A; }
@@ -1411,7 +1411,7 @@
                 <div class="bg-gradient-to-r from-brand-black to-gray-800 text-white p-6 md:p-8">
                     <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                         <div>
-                            <span class="text-brand-cyan-strong text-sm font-bold tracking-wider">CASE 01</span>
+                            <span class="text-flame text-sm font-bold tracking-wider">CASE 01</span>
                             <h3 class="text-2xl md:text-3xl font-bold mt-2">梶田医院様</h3>
                         </div>
                         <div class="text-sm text-gray-300">
@@ -1525,7 +1525,7 @@
                 <div class="relative z-10 p-10 md:p-16 lg:p-20">
                     <div class="max-w-2xl">
                         <span
-                            class="text-brand-cyan-strong text-sm font-bold tracking-[0.2em] uppercase block mb-6 font-en">Get
+                            class="text-flame text-sm font-bold tracking-[0.2em] uppercase block mb-6 font-en">Get
                             Started</span>
                 <h2 class="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-6 leading-tight">
                             売る側にも、買う側にも、<br class="hidden md:inline">独立した臨床レビューを。
@@ -1537,7 +1537,7 @@
                         <div class="flex flex-col sm:flex-row gap-4 mb-8">
                             <a href="services.html#step1"
                                 onclick="if(window.gtag)gtag('event','cta_click',{label:'home_getstarted_hospital_light_review'})"
-                                class="inline-flex items-center justify-center px-10 py-5 sm:min-w-[260px] bg-brand-cyan-strong text-brand-black font-bold text-lg rounded-full hover:bg-white transition cta-balanced">
+                                class="inline-flex items-center justify-center px-10 py-5 sm:min-w-[260px] bg-flame text-brand-black font-bold text-lg rounded-full hover:bg-white transition cta-balanced">
                                 <span class="hidden sm:inline">医療機関向けレビューを見る</span><span class="sm:hidden">医療機関向け</span> <svg class="" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-arrow-right"></use></svg>
                             </a>
                             <a href="consulting.html#pricing"

--- a/index.html
+++ b/index.html
@@ -1659,61 +1659,46 @@
     </section>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture>
-                            <source srcset="Cursorvers_logo_white.webp" type="image/webp">
-                            <img src="Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers inverted logomark" class="h-10 w-10 rounded-full border border-white/20">
-                        </picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関</p>
-                </div>
-                <div class="footer-link-columns flex flex-col sm:flex-row gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="news.html" class="hover:text-white transition">お知らせ</a></li>
-                            <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition">Cursorvers.edu <span class="text-xs text-gray-500">（個人向け）</span></a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="mt-20 pt-10 border-t border-gray-800">
-                <p class="text-center text-sm text-gray-300 mb-6">※
-                    当事業者は免税事業者です。インボイス（適格請求書）は発行できないため、消費税の仕入税額控除にはご利用いただけません。<a href="tokushoho.html"
-                        class="underline hover:text-white ml-1">詳細はこちら</a></p>
-                <div
-                    class="flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                    <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                    <div class="flex gap-6 text-xl">
-                        <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                            target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                            <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-                        </a>
-                    </div>
-                </div>
-                <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-            </div>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&family=Zen+Old+Mincho:wght@700;900&family=Kaisei+Tokumin:wght@700;800&family=Shippori+Antique+B1&family=New+Tegomin&family=Noto+Serif+JP:wght@700;900&family=Yuji+Mai&family=Yuji+Syuku&family=Klee+One:wght@600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     <style>
         body { font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif; font-feature-settings: "palt"; background: #fff; color: #0F172A; }

--- a/message.html
+++ b/message.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/message.html
+++ b/message.html
@@ -151,55 +151,46 @@
         </div>
     </main>
 
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture>
-                            <source srcset="Cursorvers_logo_white.webp" type="image/webp">
-                            <img src="Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers inverted logomark" class="h-10 w-10 rounded-full border border-white/20">
-                        </picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関</p>
-                </div>
-                <div class="footer-link-columns flex flex-col sm:flex-row gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="news.html" class="hover:text-white transition">お知らせ</a></li>
-                            <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition">Cursorvers.edu <span class="text-xs text-gray-500">（個人向け）</span></a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="mt-20 pt-10 border-t border-gray-800 flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <div class="flex gap-6 text-xl">
-                    <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                        target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                        <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-                    </a>
-                </div>
-            </div>
-            <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script></body>

--- a/message.html
+++ b/message.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/message.html
+++ b/message.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/message.html
+++ b/message.html
@@ -83,7 +83,7 @@
         <div class="max-w-4xl mx-auto">
             <div class="text-center mb-16">
                 <span class="text-flame text-xs font-bold tracking-[0.2em] uppercase font-en block mb-6">Founder</span>
-                <h1 class="text-4xl md:text-5xl font-bold mt-6 leading-tight">
+                <h1 class="hero-h1 text-4xl md:text-5xl font-bold mt-6 leading-tight">
                     AI運用の安全と継続を、<br class="md:hidden">
                     <span class="whitespace-nowrap">医療AIに。</span>
                 </h1>

--- a/news.html
+++ b/news.html
@@ -157,55 +157,46 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture>
-                            <source srcset="Cursorvers_logo_white.webp" type="image/webp">
-                            <img src="Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers" class="h-10 w-10 rounded-full border border-white/20">
-                        </picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">医療AIの"産業医" — 提案前に、責任分界を整える</p>
-                </div>
-                <div class="flex gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="news.html" class="text-white font-medium">お知らせ</a></li>
-                            <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition">Cursorvers.edu <span class="text-xs text-gray-500">（個人向け）</span></a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="mt-20 pt-10 border-t border-gray-800 flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <div class="flex gap-6 text-xl">
-                    <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                        target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                        <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-                    </a>
-                </div>
-            </div>
-            <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script></body>

--- a/news.html
+++ b/news.html
@@ -38,7 +38,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/news.html
+++ b/news.html
@@ -38,7 +38,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>
@@ -145,7 +145,7 @@
                         <a href="news/2026-02-10-guidescope.html" class="group flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-6 py-6 hover:bg-gray-50 -mx-4 px-4 rounded-lg transition-colors">
                             <div class="flex items-center gap-3 shrink-0">
                                 <time datetime="2026-02-10" class="text-sm text-gray-500 font-en whitespace-nowrap">2026.02.10</time>
-                                <span class="inline-block bg-brand-cyan/15 text-flame text-xs font-bold px-3 py-1 rounded">プロダクト</span>
+                                <span class="inline-block bg-flame/10 text-flame text-xs font-bold px-3 py-1 rounded">プロダクト</span>
                             </div>
                             <p class="text-base md:text-lg font-medium text-brand-black group-hover:text-flame transition-colors flex-1">GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ</p>
                             <svg class="hidden sm:block shrink-0 text-gray-300 group-hover:text-flame transition-colors" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 5l7 7-7 7"/></svg>

--- a/news.html
+++ b/news.html
@@ -38,7 +38,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/news.html
+++ b/news.html
@@ -98,7 +98,7 @@
                         <li class="text-brand-black font-medium" aria-current="page">お知らせ</li>
                     </ol>
                 </nav>
-                <h1 class="text-3xl md:text-4xl font-bold text-brand-black">お知らせ</h1>
+                <h1 class="hero-h1 text-3xl md:text-4xl font-bold text-brand-black">お知らせ</h1>
                 <p class="mt-2 text-lg text-gray-500 font-en">News &amp; Updates</p>
             </div>
         </section>

--- a/news/2026-02-10-guidescope.html
+++ b/news/2026-02-10-guidescope.html
@@ -237,55 +237,46 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture>
-                            <source srcset="../Cursorvers_logo_white.webp" type="image/webp">
-                            <img src="../Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers" class="h-10 w-10 rounded-full border border-white/20">
-                        </picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">医療AIの"産業医" — 提案前に、責任分界を整える</p>
-                </div>
-                <div class="flex gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="../services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="../message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="../news.html" class="hover:text-white transition">お知らせ</a></li>
-                            <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition">Cursorvers.edu <span class="text-xs text-gray-500">（個人向け）</span></a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="../privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="../terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="../tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="../contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="mt-20 pt-10 border-t border-gray-800 flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <div class="flex gap-6 text-xl">
-                    <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                        target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                        <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-                    </a>
-                </div>
-            </div>
-            <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>67f1457</span></p>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="../Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='../Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="../services.html">医療機関向け</a></li>
+        <li><a href="../consulting.html">ベンダー向け</a></li>
+        <li><a href="../subsidy.html">DX資金調達</a></li>
+        <li><a href="../gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="../message.html">創業者メッセージ</a></li>
+        <li><a href="../news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="../privacy.html">プライバシーポリシー</a></li>
+        <li><a href="../terms.html">利用規約</a></li>
+        <li><a href="../tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="../contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="../assets/js/nav.js" defer></script>
     <script src="../assets/js/cookie-consent.js" defer></script></body>

--- a/news/2026-02-10-guidescope.html
+++ b/news/2026-02-10-guidescope.html
@@ -110,7 +110,7 @@
                     <time datetime="2026-02-10" class="text-sm text-gray-500 font-en">2026.02.10</time>
                     <span class="inline-block bg-brand-cyan/15 text-flame text-xs font-bold px-3 py-1 rounded">プロダクト</span>
                 </div>
-                <h1 class="text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ</h1>
+                <h1 class="hero-h1 text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ</h1>
             </div>
         </section>
 

--- a/news/2026-02-10-guidescope.html
+++ b/news/2026-02-10-guidescope.html
@@ -108,7 +108,7 @@
                 </nav>
                 <div class="flex items-center gap-3 mb-4">
                     <time datetime="2026-02-10" class="text-sm text-gray-500 font-en">2026.02.10</time>
-                    <span class="inline-block bg-brand-cyan/15 text-flame text-xs font-bold px-3 py-1 rounded">プロダクト</span>
+                    <span class="inline-block bg-flame/10 text-flame text-xs font-bold px-3 py-1 rounded">プロダクト</span>
                 </div>
                 <h1 class="hero-h1 text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ</h1>
             </div>

--- a/news/2026-02-16-ggen-partnership.html
+++ b/news/2026-02-16-ggen-partnership.html
@@ -112,7 +112,7 @@
                 </div>
                 <h1 class="text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">Google Cloud プレミアパートナー<br class="hidden md:inline"> 株式会社G-gen とパートナーシップを締結</h1>
                 <div class="mt-8 md:mt-10 max-w-4xl overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm" aria-label="Cursorvers と G-gen のパートナーシップ">
-                    <div class="h-2 bg-gradient-to-r from-flame via-cyan-200 to-flame"></div>
+                    <div class="h-2 bg-gradient-to-r from-flame via-slate-200 to-flame"></div>
                     <div class="px-6 py-8 md:px-12 md:py-10">
                         <div class="flex flex-col md:flex-row items-center justify-center gap-7 md:gap-12">
                             <a href="../index.html" class="flex h-20 w-56 md:h-24 md:w-64 items-center justify-center gap-4 rounded-xl bg-white p-4">
@@ -129,7 +129,7 @@
                         </div>
                         <p class="mt-5 text-center text-base md:text-lg font-bold text-brand-black">Google Cloud 環境での医療AI基盤構築と運用支援を共同で推進</p>
                     </div>
-                    <div class="h-2 bg-gradient-to-r from-flame via-cyan-200 to-flame"></div>
+                    <div class="h-2 bg-gradient-to-r from-flame via-slate-200 to-flame"></div>
                 </div>
             </div>
         </section>

--- a/news/2026-02-16-ggen-partnership.html
+++ b/news/2026-02-16-ggen-partnership.html
@@ -113,9 +113,9 @@
                 <h1 class="text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">Google Cloud プレミアパートナー<br class="hidden md:inline"> 株式会社G-gen とパートナーシップを締結</h1>
                 <div class="mt-8 md:mt-10 max-w-4xl overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm" aria-label="Cursorvers と G-gen のパートナーシップ">
                     <div class="h-2 bg-gradient-to-r from-flame via-cyan-200 to-flame"></div>
-                    <div class="px-6 py-10 md:px-12 md:py-14">
+                    <div class="px-6 py-8 md:px-12 md:py-10">
                         <div class="flex flex-col md:flex-row items-center justify-center gap-7 md:gap-12">
-                            <a href="../index.html" class="flex h-28 w-64 md:h-32 md:w-72 items-center justify-center gap-4 rounded-xl bg-white p-4">
+                            <a href="../index.html" class="flex h-20 w-56 md:h-24 md:w-64 items-center justify-center gap-4 rounded-xl bg-white p-4">
                                 <picture class="shrink-0">
                                     <source srcset="../Cursorvers_logo_navy.webp" type="image/webp">
                                     <img src="../Cursorvers_logo_navy.jpeg" alt="Cursorvers logomark" class="h-12 w-12 md:h-14 md:w-14 object-contain mix-blend-multiply" width="56" height="56" loading="eager" decoding="async" fetchpriority="high">
@@ -123,11 +123,11 @@
                                 <span class="font-en text-xl md:text-2xl font-bold tracking-wide text-brand-charcoal uppercase">Cursorvers</span>
                             </a>
                             <span class="text-4xl md:text-5xl font-light text-flame" aria-hidden="true">×</span>
-                            <a href="https://g-gen.co.jp/" target="_blank" rel="noopener noreferrer" class="flex h-28 w-64 md:h-32 md:w-72 items-center justify-center rounded-xl bg-white p-5 hover:bg-gray-50 transition-colors">
+                            <a href="https://g-gen.co.jp/" target="_blank" rel="noopener noreferrer" class="flex h-20 w-56 md:h-24 md:w-64 items-center justify-center rounded-xl bg-white p-5 hover:bg-gray-50 transition-colors">
                                 <img src="../images/logo-ggen.png" alt="G-gen logo" class="max-h-16 md:max-h-20 max-w-48 md:max-w-56 object-contain" width="131" height="61" loading="eager" decoding="async" fetchpriority="high">
                             </a>
                         </div>
-                        <p class="mt-7 text-center text-base md:text-lg font-bold text-brand-black">Google Cloud 環境での医療AI基盤構築と運用支援を共同で推進</p>
+                        <p class="mt-5 text-center text-base md:text-lg font-bold text-brand-black">Google Cloud 環境での医療AI基盤構築と運用支援を共同で推進</p>
                     </div>
                     <div class="h-2 bg-gradient-to-r from-flame via-cyan-200 to-flame"></div>
                 </div>

--- a/news/2026-02-16-ggen-partnership.html
+++ b/news/2026-02-16-ggen-partnership.html
@@ -110,7 +110,7 @@
                     <time datetime="2026-02-16" class="text-sm text-gray-500 font-en">2026.02.16</time>
                     <span class="inline-block bg-emerald-50 text-emerald-700 text-xs font-bold px-3 py-1 rounded">パートナーシップ</span>
                 </div>
-                <h1 class="text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">Google Cloud プレミアパートナー<br class="hidden md:inline"> 株式会社G-gen とパートナーシップを締結</h1>
+                <h1 class="hero-h1 text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">Google Cloud プレミアパートナー<br class="hidden md:inline"> 株式会社G-gen とパートナーシップを締結</h1>
                 <div class="mt-8 md:mt-10 max-w-4xl overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm" aria-label="Cursorvers と G-gen のパートナーシップ">
                     <div class="h-2 bg-gradient-to-r from-flame via-slate-200 to-flame"></div>
                     <div class="px-6 py-8 md:px-12 md:py-10">

--- a/news/2026-02-16-ggen-partnership.html
+++ b/news/2026-02-16-ggen-partnership.html
@@ -234,55 +234,46 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture>
-                            <source srcset="../Cursorvers_logo_white.webp" type="image/webp">
-                            <img src="../Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers" class="h-10 w-10 rounded-full border border-white/20">
-                        </picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">医療AIの"産業医" — 提案前に、責任分界を整える</p>
-                </div>
-                <div class="flex gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="../services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="../message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="../news.html" class="hover:text-white transition">お知らせ</a></li>
-                            <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition">Cursorvers.edu <span class="text-xs text-gray-500">（個人向け）</span></a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="../privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="../terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="../tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="../contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="mt-20 pt-10 border-t border-gray-800 flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <div class="flex gap-6 text-xl">
-                    <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                        target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                        <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-                    </a>
-                </div>
-            </div>
-            <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>a322e3a</span></p>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="../Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='../Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="../services.html">医療機関向け</a></li>
+        <li><a href="../consulting.html">ベンダー向け</a></li>
+        <li><a href="../subsidy.html">DX資金調達</a></li>
+        <li><a href="../gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="../message.html">創業者メッセージ</a></li>
+        <li><a href="../news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="../privacy.html">プライバシーポリシー</a></li>
+        <li><a href="../terms.html">利用規約</a></li>
+        <li><a href="../tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="../contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="../assets/js/nav.js" defer></script>
     <script src="../assets/js/cookie-consent.js" defer></script></body>

--- a/news/2026-02-18-health-isac-japan.html
+++ b/news/2026-02-18-health-isac-japan.html
@@ -113,9 +113,9 @@
                 <h1 class="text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">Health ISAC Japan の協賛会員として登録されました</h1>
                 <div class="mt-8 md:mt-10 max-w-4xl overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm" aria-label="Cursorvers と Health ISAC Japan の協賛会員登録">
                     <div class="h-2 bg-gradient-to-r from-flame via-cyan-200 to-flame"></div>
-                    <div class="px-6 py-10 md:px-12 md:py-14">
+                    <div class="px-6 py-8 md:px-12 md:py-10">
                         <div class="flex flex-col md:flex-row items-center justify-center gap-7 md:gap-12">
-                            <a href="../index.html" class="flex h-28 w-64 md:h-32 md:w-72 items-center justify-center gap-4 rounded-xl bg-white p-4">
+                            <a href="../index.html" class="flex h-20 w-56 md:h-24 md:w-64 items-center justify-center gap-4 rounded-xl bg-white p-4">
                                 <picture class="shrink-0">
                                     <source srcset="../Cursorvers_logo_navy.webp" type="image/webp">
                                     <img src="../Cursorvers_logo_navy.jpeg" alt="Cursorvers logomark" class="h-12 w-12 md:h-14 md:w-14 object-contain mix-blend-multiply" width="56" height="56" loading="eager" decoding="async" fetchpriority="high">
@@ -123,11 +123,11 @@
                                 <span class="font-en text-xl md:text-2xl font-bold tracking-wide text-brand-charcoal uppercase">Cursorvers</span>
                             </a>
                             <span class="text-4xl md:text-5xl font-light text-flame" aria-hidden="true">×</span>
-                            <a href="https://health-isac-japan.jp/orgmember/" target="_blank" rel="noopener noreferrer" class="flex h-28 w-64 md:h-32 md:w-72 items-center justify-center rounded-xl bg-white p-5 hover:bg-gray-50 transition-colors">
+                            <a href="https://health-isac-japan.jp/orgmember/" target="_blank" rel="noopener noreferrer" class="flex h-20 w-56 md:h-24 md:w-64 items-center justify-center rounded-xl bg-white p-5 hover:bg-gray-50 transition-colors">
                                 <img src="../images/logo-health-isac-japan.png" alt="Health ISAC Japan logo" class="max-h-16 md:max-h-20 max-w-48 md:max-w-56 object-contain" width="187" height="73" loading="eager" decoding="async" fetchpriority="high">
                             </a>
                         </div>
-                        <p class="mt-7 text-center text-base md:text-lg font-bold text-brand-black">医療サイバーセキュリティの情報共有をAIガバナンス支援へ接続</p>
+                        <p class="mt-5 text-center text-base md:text-lg font-bold text-brand-black">医療サイバーセキュリティの情報共有をAIガバナンス支援へ接続</p>
                     </div>
                     <div class="h-2 bg-gradient-to-r from-flame via-cyan-200 to-flame"></div>
                 </div>

--- a/news/2026-02-18-health-isac-japan.html
+++ b/news/2026-02-18-health-isac-japan.html
@@ -112,7 +112,7 @@
                 </div>
                 <h1 class="text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">Health ISAC Japan の協賛会員として登録されました</h1>
                 <div class="mt-8 md:mt-10 max-w-4xl overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm" aria-label="Cursorvers と Health ISAC Japan の協賛会員登録">
-                    <div class="h-2 bg-gradient-to-r from-flame via-cyan-200 to-flame"></div>
+                    <div class="h-2 bg-gradient-to-r from-flame via-slate-200 to-flame"></div>
                     <div class="px-6 py-8 md:px-12 md:py-10">
                         <div class="flex flex-col md:flex-row items-center justify-center gap-7 md:gap-12">
                             <a href="../index.html" class="flex h-20 w-56 md:h-24 md:w-64 items-center justify-center gap-4 rounded-xl bg-white p-4">
@@ -129,7 +129,7 @@
                         </div>
                         <p class="mt-5 text-center text-base md:text-lg font-bold text-brand-black">医療サイバーセキュリティの情報共有をAIガバナンス支援へ接続</p>
                     </div>
-                    <div class="h-2 bg-gradient-to-r from-flame via-cyan-200 to-flame"></div>
+                    <div class="h-2 bg-gradient-to-r from-flame via-slate-200 to-flame"></div>
                 </div>
             </div>
         </section>

--- a/news/2026-02-18-health-isac-japan.html
+++ b/news/2026-02-18-health-isac-japan.html
@@ -228,55 +228,46 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture>
-                            <source srcset="../Cursorvers_logo_white.webp" type="image/webp">
-                            <img src="../Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers" class="h-10 w-10 rounded-full border border-white/20">
-                        </picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">医療AIの"産業医" — 提案前に、責任分界を整える</p>
-                </div>
-                <div class="flex gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="../services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="../message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="../news.html" class="hover:text-white transition">お知らせ</a></li>
-                            <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition">Cursorvers.edu <span class="text-xs text-gray-500">（個人向け）</span></a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="../privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="../terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="../tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="../contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="mt-20 pt-10 border-t border-gray-800 flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <div class="flex gap-6 text-xl">
-                    <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                        target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                        <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-                    </a>
-                </div>
-            </div>
-            <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>a322e3a</span></p>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="../Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='../Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="../services.html">医療機関向け</a></li>
+        <li><a href="../consulting.html">ベンダー向け</a></li>
+        <li><a href="../subsidy.html">DX資金調達</a></li>
+        <li><a href="../gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="../message.html">創業者メッセージ</a></li>
+        <li><a href="../news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="../privacy.html">プライバシーポリシー</a></li>
+        <li><a href="../terms.html">利用規約</a></li>
+        <li><a href="../tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="../contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="../assets/js/nav.js" defer></script>
     <script src="../assets/js/cookie-consent.js" defer></script></body>

--- a/news/2026-02-18-health-isac-japan.html
+++ b/news/2026-02-18-health-isac-japan.html
@@ -110,7 +110,7 @@
                     <time datetime="2026-02-18" class="text-sm text-gray-500 font-en">2026.02.18</time>
                     <span class="inline-block bg-flame/10 text-flame text-xs font-bold px-3 py-1 rounded">セキュリティ</span>
                 </div>
-                <h1 class="text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">Health ISAC Japan の協賛会員として登録されました</h1>
+                <h1 class="hero-h1 text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">Health ISAC Japan の協賛会員として登録されました</h1>
                 <div class="mt-8 md:mt-10 max-w-4xl overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm" aria-label="Cursorvers と Health ISAC Japan の協賛会員登録">
                     <div class="h-2 bg-gradient-to-r from-flame via-slate-200 to-flame"></div>
                     <div class="px-6 py-8 md:px-12 md:py-10">

--- a/news/2026-03-02-hospital-ai-implementation.html
+++ b/news/2026-03-02-hospital-ai-implementation.html
@@ -147,7 +147,7 @@
                     <time datetime="2026-03-02" class="text-sm text-gray-500 font-en">2026.03.02</time>
                     <span class="inline-block bg-navy/10 text-navy text-xs font-bold px-3 py-1 rounded">コラム</span>
                 </div>
-                <h1 class="text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">「病院AI導入には順番がある」<br class="hidden sm:inline">— 内科医×エンジニアが示す実装の地図</h1>
+                <h1 class="hero-h1 text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">「病院AI導入には順番がある」<br class="hidden sm:inline">— 内科医×エンジニアが示す実装の地図</h1>
 
                 <!-- Attribution Banner -->
                 <div class="mt-6 md:mt-8 flex items-center gap-4 bg-white rounded-xl border border-gray-200 p-4 md:p-5">

--- a/news/2026-03-02-hospital-ai-implementation.html
+++ b/news/2026-03-02-hospital-ai-implementation.html
@@ -359,55 +359,46 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture>
-                            <source srcset="../Cursorvers_logo_white.webp" type="image/webp">
-                            <img src="../Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers" class="h-10 w-10 rounded-full border border-white/20">
-                        </picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">医療AIの"産業医" — 提案前に、責任分界を整える</p>
-                </div>
-                <div class="flex gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="../services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="../message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="../news.html" class="hover:text-white transition">お知らせ</a></li>
-                            <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition">Cursorvers.edu <span class="text-xs text-gray-500">（個人向け）</span></a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="../privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="../terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="../tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="../contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="mt-20 pt-10 border-t border-gray-800 flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <div class="flex gap-6 text-xl">
-                    <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                        target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                        <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-                    </a>
-                </div>
-            </div>
-            <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>a322e3a</span></p>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="../Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='../Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="../services.html">医療機関向け</a></li>
+        <li><a href="../consulting.html">ベンダー向け</a></li>
+        <li><a href="../subsidy.html">DX資金調達</a></li>
+        <li><a href="../gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="../message.html">創業者メッセージ</a></li>
+        <li><a href="../news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="../privacy.html">プライバシーポリシー</a></li>
+        <li><a href="../terms.html">利用規約</a></li>
+        <li><a href="../tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="../contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="../assets/js/nav.js" defer></script>
     <script src="../assets/js/cookie-consent.js" defer></script></body>

--- a/privacy.html
+++ b/privacy.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/privacy.html
+++ b/privacy.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/privacy.html
+++ b/privacy.html
@@ -176,22 +176,46 @@
         </div>
     </main>
 
-    <footer class="bg-white border-t border-gray-200 py-8 text-center text-sm text-gray-600">
-        <div class="flex flex-wrap justify-center gap-6 mb-4">
-            <a href="privacy.html" class="hover:text-flame transition">プライバシーポリシー</a>
-            <a href="terms.html" class="hover:text-flame transition">利用規約</a>
-            <a href="tokushoho.html" class="hover:text-flame transition">特定商取引法に基づく表記</a>
-            <a href="news.html" class="hover:text-flame transition">お知らせ</a>
-            <a href="contact.html" class="hover:text-flame transition">お問い合わせ</a>
-        </div>
-        <div class="flex justify-center gap-6 text-lg mb-4">
-            <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/" target="_blank" rel="noopener noreferrer" class="hover:text-flame transition" aria-label="LinkedIn">
-                <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-            </a>
-        </div>
-        <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-        <p class="mt-2 text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script></body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/services.html
+++ b/services.html
@@ -408,7 +408,7 @@
 
                 <div class="grid md:grid-cols-2 gap-8">
                     <!-- ライトレビュー -->
-                    <div class="bg-gradient-to-br from-flame/5 to-cyan-50 rounded-2xl p-8 md:p-10 flex flex-col">
+                    <div class="bg-gradient-to-br from-flame/5 to-slate-50 rounded-2xl p-8 md:p-10 flex flex-col">
                         <div class="flex items-center gap-3 mb-4">
                             <span class="bg-flame text-white text-sm font-bold px-3 py-1 rounded-full">軽量</span>
                             <span class="text-text-tertiary text-lg">オンライン完結</span>
@@ -498,7 +498,7 @@
                 <p class="text-lg text-flame font-semibold mb-8"><svg class="mr-2" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-info-circle"></use></svg>必要時のみ、3ヶ月の伴走支援を設計します</p>
 
                 <!-- GOV-Lead Banner -->
-                <div class="bg-gradient-to-r from-flame/5 to-cyan-50 rounded-2xl p-8 md:p-10 mb-12 border border-flame/10">
+                <div class="bg-gradient-to-r from-flame/5 to-slate-50 rounded-2xl p-8 md:p-10 mb-12 border border-flame/10">
                     <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
                         <div class="flex-1">
                             <div class="flex items-center gap-3 mb-3">
@@ -629,7 +629,7 @@
                             </thead>
                             <tbody>
                                 <!-- おすすめ対象（サマリ行） -->
-                                <tr class="bg-gradient-to-r from-flame/5 to-cyan-50">
+                                <tr class="bg-gradient-to-r from-flame/5 to-slate-50">
                                     <td class="p-4 text-lg font-bold text-brand-black">おすすめ対象</td>
                                     <td class="p-4 text-base text-center text-text-secondary leading-relaxed">まずは相談<br>したい方</td>
                                     <td class="p-4 text-base text-center bg-flame/10 font-semibold text-brand-black leading-relaxed">90日で体制を<br>整えたい方</td>
@@ -663,12 +663,12 @@
                                 <tr class="feature-category">
                                     <td colspan="4" class="p-4 text-lg font-bold text-flame"><svg class="mr-2" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-rocket"></use></svg>90日運用定着支援</td>
                                 </tr>
-                                <tr class="bg-amber-50/50 border-l-4 border-l-yellow-400">
-                                    <td class="p-4 text-lg font-semibold">90日運用定着プラン実行 <span class="text-sm bg-amber-400 text-amber-900 px-2 py-0.5 rounded ml-1">重要</span></td>
+                                <tr class="bg-slate-50/50 border-l-4 border-l-slate-400">
+                                    <td class="p-4 text-lg font-semibold">90日運用定着プラン実行 <span class="text-sm bg-slate-400 text-slate-900 px-2 py-0.5 rounded ml-1">重要</span></td>
                                     <td class="p-4 text-center"><svg class="text-gray-400 text-xl" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-xmark"></use></svg>
                                     </td>
                                     <td class="p-4 text-center bg-flame/10"><svg class="text-flame text-xl" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-circle-check"></use></svg></td>
-                                    <td class="p-4 text-center bg-amber-50/30"><svg class="text-flame text-xl" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-circle-check"></use></svg></td>
+                                    <td class="p-4 text-center bg-slate-50/30"><svg class="text-flame text-xl" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-circle-check"></use></svg></td>
                                 </tr>
                                 <tr>
                                     <td class="p-4 text-lg">規程・ガイドライン整備支援</td>
@@ -696,19 +696,19 @@
                                 <tr class="feature-category">
                                     <td colspan="4" class="p-4 text-lg font-bold text-flame"><svg class="mr-2" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-building"></use></svg>現地訪問</td>
                                 </tr>
-                                <tr class="bg-amber-50/50 border-l-4 border-l-yellow-400">
-                                    <td class="p-4 text-lg font-semibold">現地訪問 <span class="text-sm bg-amber-400 text-amber-900 px-2 py-0.5 rounded ml-1">重要</span></td>
+                                <tr class="bg-slate-50/50 border-l-4 border-l-slate-400">
+                                    <td class="p-4 text-lg font-semibold">現地訪問 <span class="text-sm bg-slate-400 text-slate-900 px-2 py-0.5 rounded ml-1">重要</span></td>
                                     <td class="p-4 text-center"><svg class="text-gray-400 text-xl" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-xmark"></use></svg>
                                     </td>
                                     <td class="p-4 text-lg text-center bg-flame/10 font-semibold">初回1回</td>
-                                    <td class="p-4 text-lg text-center bg-amber-50/30 font-bold">毎月1回</td>
+                                    <td class="p-4 text-lg text-center bg-slate-50/30 font-bold">毎月1回</td>
                                 </tr>
-                                <tr class="bg-amber-50/50 border-l-4 border-l-yellow-400">
-                                    <td class="p-4 text-lg font-semibold">委員会・幹部会への陪席 <span class="text-sm bg-amber-400 text-amber-900 px-2 py-0.5 rounded ml-1">重要</span></td>
+                                <tr class="bg-slate-50/50 border-l-4 border-l-slate-400">
+                                    <td class="p-4 text-lg font-semibold">委員会・幹部会への陪席 <span class="text-sm bg-slate-400 text-slate-900 px-2 py-0.5 rounded ml-1">重要</span></td>
                                     <td class="p-4 text-center"><svg class="text-gray-400 text-xl" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-xmark"></use></svg>
                                     </td>
                                     <td class="p-4 text-center bg-flame/5"><svg class="text-gray-400 text-xl" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-xmark"></use></svg></td>
-                                    <td class="p-4 text-center bg-amber-50/30"><svg class="text-flame text-xl" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-circle-check"></use></svg></td>
+                                    <td class="p-4 text-center bg-slate-50/30"><svg class="text-flame text-xl" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-circle-check"></use></svg></td>
                                 </tr>
 
                                 <!-- 情報提供 -->
@@ -744,12 +744,12 @@
                         <span class="flex items-center gap-2"><svg class="text-flame" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-circle-check"></use></svg> 含む（重点）</span>
                         <span class="flex items-center gap-2"><svg class="text-flame" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-check"></use></svg> 含む</span>
                         <span class="flex items-center gap-2"><svg class="text-gray-400" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-xmark"></use></svg> 含まない</span>
-                        <span class="flex items-center gap-2"><span class="inline-block w-4 h-4 bg-amber-50 border-l-4 border-l-yellow-400"></span> 重要な差分</span>
+                        <span class="flex items-center gap-2"><span class="inline-block w-4 h-4 bg-slate-50 border-l-4 border-l-slate-400"></span> 重要な差分</span>
                     </div>
                 </div>
 
                 <!-- Subsidy Info -->
-                <div class="bg-gradient-to-r from-flame/5 to-cyan-50 rounded-2xl p-8 text-center mt-10 border border-flame/10">
+                <div class="bg-gradient-to-r from-flame/5 to-slate-50 rounded-2xl p-8 text-center mt-10 border border-flame/10">
                     <p class="text-2xl font-bold mb-2">
                         <svg class="text-flame mr-2" width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-building"></use></svg>
                         IT導入補助金の活用支援

--- a/services.html
+++ b/services.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     
     <style>

--- a/services.html
+++ b/services.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     
     <style>

--- a/services.html
+++ b/services.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     
     <style>

--- a/services.html
+++ b/services.html
@@ -323,7 +323,7 @@
             <!-- Hero Content -->
             <div class="relative z-10 max-w-4xl mx-auto mb-24 md:mb-32">
                 <p class="text-lg font-semibold text-flame mb-4 font-en">医療機関向け</p>
-                <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
+                <h1 class="hero-h1 text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
                     AI導入判断と運用監査の<br><span class="gradient-text">第三者レビュー</span>
                 </h1>
                 <p class="text-xl md:text-2xl text-text-secondary max-w-2xl mx-auto mb-8 leading-relaxed text-balance">

--- a/services.html
+++ b/services.html
@@ -987,53 +987,46 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture><source srcset="Cursorvers_logo_white.webp" type="image/webp"><img src="Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers"
-                            class="h-10 w-10 rounded-full border border-white/20"></picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関</p>
-                </div>
-                <div class="flex gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="services.html" class="hover:text-white transition">サービス</a></li>
-                            <li><a href="message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="news.html" class="hover:text-white transition">お知らせ</a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div
-                class="mt-20 pt-10 border-t border-gray-800 flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                <div class="flex gap-6 text-xl">
-                    <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/"
-                        target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                        <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-linkedin"></use></svg>
-                    </a>
-                </div>
-            </div>
-            <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script>

--- a/subsidy.html
+++ b/subsidy.html
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     
     <style>

--- a/subsidy.html
+++ b/subsidy.html
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     
     <style>

--- a/subsidy.html
+++ b/subsidy.html
@@ -541,15 +541,15 @@
                         <span><strong class="text-brand-black">事前着手（交付決定前の契約・発注・支払い）は補助対象外</strong>となる場合があります。スケジュールにご注意ください。</span>
                     </li>
                     <li class="flex items-start gap-3">
-                        <svg class="text-orange-500 mt-0.5 flex-shrink-0 text-lg" width="1.2em" height="1.2em" fill="currentColor" aria-hidden="true"><use href="#icon-triangle-exclamation"></use></svg>
+                        <svg class="text-flame mt-0.5 flex-shrink-0 text-lg" width="1.2em" height="1.2em" fill="currentColor" aria-hidden="true"><use href="#icon-triangle-exclamation"></use></svg>
                         <span>採択・交付・補助額は審査により決定され、<strong class="text-brand-black">保証はできません</strong>。</span>
                     </li>
                     <li class="flex items-start gap-3">
-                        <svg class="text-orange-500 mt-0.5 flex-shrink-0 text-lg" width="1.2em" height="1.2em" fill="currentColor" aria-hidden="true"><use href="#icon-triangle-exclamation"></use></svg>
+                        <svg class="text-flame mt-0.5 flex-shrink-0 text-lg" width="1.2em" height="1.2em" fill="currentColor" aria-hidden="true"><use href="#icon-triangle-exclamation"></use></svg>
                         <span>補助対象経費・上限額・要件は制度/公募回により変わります。<strong class="text-brand-black">必ず最新の公募要領をご確認ください</strong>。</span>
                     </li>
                     <li class="flex items-start gap-3">
-                        <svg class="text-orange-500 mt-0.5 flex-shrink-0 text-lg" width="1.2em" height="1.2em" fill="currentColor" aria-hidden="true"><use href="#icon-triangle-exclamation"></use></svg>
+                        <svg class="text-flame mt-0.5 flex-shrink-0 text-lg" width="1.2em" height="1.2em" fill="currentColor" aria-hidden="true"><use href="#icon-triangle-exclamation"></use></svg>
                         <span>「補助事業の遂行に必要な専門家経費」等が対象となる場合がありますが、申請書・報告書など<strong class="text-brand-black">"事務局提出書類の作成・提出に係る費用"は対象外</strong>となる場合があります。</span>
                     </li>
                     <li class="flex items-start gap-3">

--- a/subsidy.html
+++ b/subsidy.html
@@ -227,7 +227,7 @@
             <div class="absolute inset-0 bg-gradient-to-b from-white/85 via-white/75 to-white/90"></div>
             <div class="relative z-10 max-w-4xl mx-auto">
                 <p class="text-lg font-semibold text-flame mb-4 font-en">Medical AI Consulting</p>
-                <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
+                <h1 class="hero-h1 text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-6">
                     医療AI導入、<br class="hidden md:inline">資金の選択肢は<br class="md:hidden"><span class="whitespace-nowrap">一つではありません</span>
                 </h1>
                 <p class="text-xl md:text-2xl text-text-secondary max-w-2xl mx-auto mb-10 leading-relaxed">

--- a/subsidy.html
+++ b/subsidy.html
@@ -36,7 +36,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     
     <style>

--- a/subsidy.html
+++ b/subsidy.html
@@ -580,55 +580,46 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-brand-black text-white py-24 relative z-10">
-        <div class="max-w-7xl mx-auto px-6 md:px-12">
-            <div class="flex flex-col md:flex-row justify-between items-start gap-16 md:gap-24">
-                <div class="max-w-sm">
-                    <div class="flex items-center gap-4 mb-8">
-                        <picture><source srcset="Cursorvers_logo_white.webp" type="image/webp"><img src="Cursorvers_logo_white.jpeg" onerror="this.style.display='none'" alt="Cursorvers inverted logomark" class="h-10 w-10 rounded-full border border-white/20"></picture>
-                        <span class="flex flex-col leading-none">
-                            <span class="text-white font-bold text-2xl font-en tracking-widest">Cursorvers</span>
-                            <span class="text-xs font-semibold text-gray-400 tracking-[0.25em]">カーソルバース</span>
-                        </span>
-                    </div>
-                    <p class="text-lg leading-relaxed text-gray-400">医療AIの"産業医" — 提案前に、責任分界を整える</p>
-                </div>
-                <div class="flex gap-16 md:gap-24">
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">リンク</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="services.html" class="hover:text-white transition">医療機関向け</a></li>
-                            <li><a href="consulting.html" class="hover:text-white transition">ベンダー向け</a></li>
-                            <li><a href="subsidy.html" class="hover:text-white transition">DX資金調達</a></li>
-                            <li><a href="message.html" class="hover:text-white transition">創業者</a></li>
-                            <li><a href="news.html" class="hover:text-white transition">お知らせ</a></li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h3 class="text-white font-bold text-lg mb-8">法的情報</h3>
-                        <ul class="space-y-5 text-gray-400 text-base">
-                            <li><a href="privacy.html" class="hover:text-white transition">プライバシーポリシー</a></li>
-                            <li><a href="terms.html" class="hover:text-white transition">利用規約</a></li>
-                            <li><a href="tokushoho.html" class="hover:text-white transition">特定商取引法に基づく表記</a></li>
-                            <li><a href="contact.html" class="hover:text-white transition">お問い合わせ</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <div class="mt-20 pt-10 border-t border-gray-800">
-                <p class="text-center text-sm text-gray-300 mb-6">※ 当事業者は免税事業者です。インボイス（適格請求書）は発行できないため、消費税の仕入税額控除にはご利用いただけません。<a href="tokushoho.html" class="underline hover:text-white ml-1">詳細はこちら</a></p>
-                <div class="flex flex-col md:flex-row justify-between items-center gap-6 font-en text-base text-gray-500">
-                    <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-                    <div class="flex gap-6 text-xl">
-                        <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition" aria-label="LinkedIn">
-                            <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="#icon-linkedin"></use></svg>
-                        </a>
-                    </div>
-                </div>
-                <p class="mt-4 text-center text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-            </div>
-        </div>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
 
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script></body>

--- a/terms.html
+++ b/terms.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/terms.html
+++ b/terms.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/terms.html
+++ b/terms.html
@@ -125,22 +125,46 @@
         </div>
     </main>
 
-    <footer class="bg-white border-t border-gray-200 py-8 text-center text-sm text-gray-600">
-        <div class="flex flex-wrap justify-center gap-6 mb-4">
-            <a href="privacy.html" class="hover:text-flame transition">プライバシーポリシー</a>
-            <a href="terms.html" class="hover:text-flame transition">利用規約</a>
-            <a href="tokushoho.html" class="hover:text-flame transition">特定商取引法に基づく表記</a>
-            <a href="news.html" class="hover:text-flame transition">お知らせ</a>
-            <a href="contact.html" class="hover:text-flame transition">お問い合わせ</a>
-        </div>
-        <div class="flex justify-center gap-6 text-lg mb-4">
-            <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/" target="_blank" rel="noopener noreferrer" class="hover:text-flame transition" aria-label="LinkedIn">
-                <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-            </a>
-        </div>
-        <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-        <p class="mt-2 text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script></body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/tokushoho.html
+++ b/tokushoho.html
@@ -164,22 +164,46 @@
         </div>
     </main>
 
-    <footer class="bg-white border-t border-gray-200 py-8 text-center text-sm text-gray-600">
-        <div class="flex flex-wrap justify-center gap-6 mb-4">
-            <a href="privacy.html" class="hover:text-flame transition">プライバシーポリシー</a>
-            <a href="terms.html" class="hover:text-flame transition">利用規約</a>
-            <a href="tokushoho.html" class="hover:text-flame transition">特定商取引法に基づく表記</a>
-            <a href="news.html" class="hover:text-flame transition">お知らせ</a>
-            <a href="contact.html" class="hover:text-flame transition">お問い合わせ</a>
-        </div>
-        <div class="flex justify-center gap-6 text-lg mb-4">
-            <a href="https://www.linkedin.com/in/%E6%AD%A3%E5%B9%B8-%E5%A4%A7%E7%94%B0%E5%8E%9F-28bb54103/" target="_blank" rel="noopener noreferrer" class="hover:text-flame transition" aria-label="LinkedIn">
-                <svg width="1em" height="1em" fill="currentColor" aria-hidden="true"><use href="./assets/icons.svg#icon-linkedin"></use></svg>
-            </a>
-        </div>
-        <p>&copy; 2026 Cursorvers All Rights Reserved.</p>
-        <p class="mt-2 text-xs text-gray-400">Build: <span data-build-id>8cb72dd</span></p>
-    </footer>
+    <footer class="site-footer" role="contentinfo">
+  <div class="site-footer__inner">
+    <div class="site-footer__brand">
+      <img src="Cursorvers_logo_white.webp" alt="Cursorvers" onerror="this.onerror=null;this.src='Cursorvers_logo_white.jpeg';">
+      <p>病院の導入判断とベンダーの提案品質を精査する、医療AI専門の第三者機関。</p>
+    </div>
+    <div class="site-footer__col">
+      <h4>Services</h4>
+      <ul>
+        <li><a href="services.html">医療機関向け</a></li>
+        <li><a href="consulting.html">ベンダー向け</a></li>
+        <li><a href="subsidy.html">DX資金調達</a></li>
+        <li><a href="gov-lead.html">GOV-Lead</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Company</h4>
+      <ul>
+        <li><a href="message.html">創業者メッセージ</a></li>
+        <li><a href="news.html">お知らせ</a></li>
+        <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
+      </ul>
+    </div>
+    <div class="site-footer__col">
+      <h4>Legal</h4>
+      <ul>
+        <li><a href="privacy.html">プライバシーポリシー</a></li>
+        <li><a href="terms.html">利用規約</a></li>
+        <li><a href="tokushoho.html">特定商取引法に基づく表記</a></li>
+        <li><a href="contact.html">お問い合わせ</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="site-footer__bottom">
+    <span>© <span id="footerYear">2026</span> Cursorvers Inc. All rights reserved.</span>
+    <span class="font-en" style="letter-spacing:.16em; text-transform:uppercase; color:#64748B;">Medical AI Assurance &amp; Continuity</span>
+  </div>
+</footer>
+<script>document.getElementById('footerYear').textContent = new Date().getFullYear();</script>
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/cookie-consent.js" defer></script></body>
 </html>

--- a/tokushoho.html
+++ b/tokushoho.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/tokushoho.html
+++ b/tokushoho.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260420k">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421g">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>

--- a/tokushoho.html
+++ b/tokushoho.html
@@ -31,7 +31,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Manrope:wght@400;600;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421h">
+    <link rel="stylesheet" href="assets/css/renewal.css?v=20260421i">
     <!-- renewal:end -->
     <!-- System fonts: no external loading needed -->
     <style>


### PR DESCRIPTION
## Summary

v20260420j ロードマップを 5 スライスで完遂。マルチエージェント批判的吟味の結果、未定義トークン `brand-cyan` の割れが後段検証で判明したため S5 を追加して完全除去。

## Slices

### 先行コミット（既存）
- `bfb3b82` お知らせカード刷新 + Hero 余白 + 見出し改行制御
- `de2a5b8` consulting ライト顧問 料金目安
- `38e62da` キャッシュバスター v=20260421g 統一

### v20260420j 真実化スライス
- **S1** `a043e63` 違反色 HTML 正規化 — 6 ファイル / 29 箇所（cyan/yellow/amber/orange-500 → slate/flame）
- **S2** `8dce3a9` Hero 書体を Zen Old Mincho @900 に統一 — renewal.css + 10 ページに `hero-h1` 適用
- **S3** `f70ca13` Footer 真実化 — SoT (`assets/partials/footer.html`) を 15 ページに適用 [codex 委譲]
- **S4** `71821ad` キャッシュバスター v=20260421h 昇格
- **S5** `3059864` 割れトークン `brand-cyan` 除去（tailwind 未定義） + v=20260421i 昇格 + `_workspace/` gitignore

## 達成度

v20260420j §3 ブランド再定位 + §4 IA/計測/表記統一 の HTML 真実化項目を **100%** 達成。

## 最終検証

- [x] 違反色 grep = 0（cyan/yellow/amber/orange-500、全 HTML）
- [x] 未定義 brand-cyan / brand-cyan-strong grep = 0
- [x] Hero `hero-h1` クラス適用 = 10 ページ（legal/gov-lead は仕様通り除外）
- [x] Footer SoT 適用 = 15 ページ
- [x] キャッシュバスター `v=20260421i` 全対象 11 ページ一致
- [ ] マージ後 Chrome / モバイル実機で目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)