### PR TITLE
chore(ci): opt in to Node 24 runtime for GHA actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: read
   pages: write
@@ -27,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install dependencies
         run: npm ci
@@ -89,7 +92,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Wait for CDN propagation
         run: sleep 30

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Lighthouse CI
         run: npm install -g @lhci/cli@0.14.x

--- a/index.html
+++ b/index.html
@@ -996,18 +996,19 @@
                                 <span class="news-visual-x" aria-hidden="true">×</span>
                                 <span class="news-visual-wordmark news-visual-wordmark--flame">GuideScope</span>
                             </div>
-                            <span class="news-visual-caption">自社プロダクト 開発中</span>
+                            <span class="news-visual-caption">自社プロダクト 提供開始</span>
                         </div>
                         <div class="news-card-v2-body">
                             <div class="news-card-v2-meta">
                                 <span class="news-card-v2-tag news-tag-flame">プロダクト</span>
                                 <time datetime="2026-02-10" class="news-card-v2-date">2026.02.10</time>
+                                <span class="inline-block bg-flame/10 text-flame text-xs font-bold px-2 py-0.5 rounded uppercase tracking-wider">LIVE</span>
                             </div>
                             <h3 class="news-card-v2-title">
-                                GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ
+                                GuideScope — 医療一次資料の突合・検証ツール 提供開始（MVP）
                             </h3>
                             <p class="news-card-v2-lede">
-                                院内マニュアルのGL準拠確認とシステム契約チェックを中核に、段階的に対応領域を拡大します。
+                                一次資料と実務文書を突合するビジョンのもと、まずはLLM向け検索プロンプト生成ツールとしてMVPを提供開始。Google Gemini・ChatGPT・Claude等で活用できます。
                             </p>
                             <span class="news-card-v2-cta">
                                 詳しく読む

--- a/news.html
+++ b/news.html
@@ -147,7 +147,7 @@
                                 <time datetime="2026-02-10" class="text-sm text-gray-500 font-en whitespace-nowrap">2026.02.10</time>
                                 <span class="inline-block bg-flame/10 text-flame text-xs font-bold px-3 py-1 rounded">プロダクト</span>
                             </div>
-                            <p class="text-base md:text-lg font-medium text-brand-black group-hover:text-flame transition-colors flex-1">GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ</p>
+                            <p class="text-base md:text-lg font-medium text-brand-black group-hover:text-flame transition-colors flex-1">GuideScope — 医療一次資料の突合・検証ツール 提供開始（MVP: LLM向け検索プロンプト生成）</p>
                             <svg class="hidden sm:block shrink-0 text-gray-300 group-hover:text-flame transition-colors" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 5l7 7-7 7"/></svg>
                         </a>
                     </li>

--- a/news/2026-02-10-guidescope.html
+++ b/news/2026-02-10-guidescope.html
@@ -15,19 +15,19 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="format-detection" content="telephone=no">
-    <title>GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ | Cursorvers</title>
-    <meta name="description" content="Cursorversは、医療機関の一次資料（省令・通知・ガイドライン・添付文書）と実務文書を突合・検証するツール「GuideScope」の開発に着手しました。">
+    <title>GuideScope — 医療一次資料の突合・検証ツール 提供開始のお知らせ | Cursorvers</title>
+    <meta name="description" content="Cursorversは、医療機関の一次資料（省令・通知・ガイドライン・添付文書）を対象に、LLM向け検索プロンプトを生成するツール「GuideScope」の提供を開始しました。">
     <link rel="canonical" href="https://cursorvers.com/news/2026-02-10-guidescope.html">
-    <meta property="og:title" content="GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ | Cursorvers">
-    <meta property="og:description" content="Cursorversは、医療機関の一次資料（省令・通知・ガイドライン・添付文書）と実務文書を突合・検証するツール「GuideScope」の開発に着手しました。">
+    <meta property="og:title" content="GuideScope — 医療一次資料の突合・検証ツール 提供開始のお知らせ | Cursorvers">
+    <meta property="og:description" content="Cursorversは、医療機関の一次資料（省令・通知・ガイドライン・添付文書）を対象に、LLM向け検索プロンプトを生成するツール「GuideScope」の提供を開始しました。">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://cursorvers.com/news/2026-02-10-guidescope.html">
     <meta property="og:image" content="https://cursorvers.com/images/og-cursorvers-logo.jpg">
     <meta property="og:site_name" content="Cursorvers">
     <meta property="og:locale" content="ja_JP">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ | Cursorvers">
-    <meta name="twitter:description" content="Cursorversは、医療機関の一次資料（省令・通知・ガイドライン・添付文書）と実務文書を突合・検証するツール「GuideScope」の開発に着手しました。">
+    <meta name="twitter:title" content="GuideScope — 医療一次資料の突合・検証ツール 提供開始のお知らせ | Cursorvers">
+    <meta name="twitter:description" content="Cursorversは、医療機関の一次資料（省令・通知・ガイドライン・添付文書）を対象に、LLM向け検索プロンプトを生成するツール「GuideScope」の提供を開始しました。">
     <meta name="twitter:image" content="https://cursorvers.com/images/og-cursorvers-logo.jpg">
 
     <!-- OGP -->
@@ -103,14 +103,15 @@
                         <li aria-hidden="true" class="text-gray-300">/</li>
                         <li><a href="../news.html" class="hover:text-flame transition">お知らせ</a></li>
                         <li aria-hidden="true" class="text-gray-300">/</li>
-                        <li class="text-brand-black font-medium truncate max-w-[200px] sm:max-w-none" aria-current="page">GuideScope 開発開始</li>
+                        <li class="text-brand-black font-medium truncate max-w-[200px] sm:max-w-none" aria-current="page">GuideScope 提供開始</li>
                     </ol>
                 </nav>
                 <div class="flex items-center gap-3 mb-4">
                     <time datetime="2026-02-10" class="text-sm text-gray-500 font-en">2026.02.10</time>
+                    <span class="inline-block bg-gray-100 text-gray-600 text-xs font-bold px-3 py-1 rounded">更新: 2026-04-23</span>
                     <span class="inline-block bg-flame/10 text-flame text-xs font-bold px-3 py-1 rounded">プロダクト</span>
                 </div>
-                <h1 class="hero-h1 text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">GuideScope — 医療一次資料の突合・検証ツール 開発開始のお知らせ</h1>
+                <h1 class="hero-h1 text-2xl md:text-3xl lg:text-4xl font-bold text-brand-black leading-tight">GuideScope — 医療一次資料の突合・検証ツール 提供開始のお知らせ</h1>
             </div>
         </section>
 
@@ -122,7 +123,7 @@
                 <div class="border-l-4 border-flame bg-flame/5 p-6 md:p-8 rounded-r-lg mb-10">
                     <p class="text-sm font-bold text-flame mb-2 font-en uppercase tracking-wider">Executive Summary</p>
                     <p class="text-base md:text-lg text-brand-black leading-relaxed">
-                        Cursorversは、医療機関の一次資料（省令・通知・ガイドライン・添付文書）と実務文書を突合・検証するツール「GuideScope」の開発に着手しました。院内マニュアルのGL準拠確認から、システム契約チェック、診療報酬改定の影響分析まで——「正しい原典」に基づく経営判断を支援します。
+                        Cursorversは、国内の医療AI関連ガイドラインや通知を探索するためのLLM向け検索プロンプト生成ツール「GuideScope」のMVPを https://cursorvers.jp/tools/guidescope/ で提供開始しました。Google Gemini・ChatGPT・Claudeで利用でき、将来的には一次資料と実務文書の突合・比較まで拡張していきます。
                     </p>
                 </div>
 
@@ -133,32 +134,32 @@
                         医療機関の経営者は、増え続ける規制・改定への対応に追われています。厚労省通知、3省2ガイドライン、診療報酬改定告示——確認すべき一次資料は膨大ですが、事務長やコンサルタントだけでは対応しきれず、「ベンダーの言い値で契約更新」「5年前のマニュアルを放置」という状況が生まれています。
                     </p>
                     <p>
-                        Cursorversは、医療AIガバナンスの伴走支援を通じて、この課題に繰り返し直面してきました。医療機関の経営者から寄せられた声を元に、一次資料と実務文書の突合・検証に特化したツールの開発を決定しました。
+                        Cursorversは、医療AIガバナンスの伴走支援を通じて、この課題に繰り返し直面してきました。そこでまず、国内の医療AI関連ガイドラインを探すための検索プロンプトを即座に生成できるMVPを https://cursorvers.jp/tools/guidescope/ で公開しました。Google Gemini・ChatGPT・Claudeでそのまま使え、一次資料と実務文書の突合・検証は次フェーズの開発テーマとして進めます。
                     </p>
 
                     <h2 class="text-xl md:text-2xl font-bold text-brand-black mb-4 mt-10">GuideScope の概要</h2>
                     <p>
-                        GuideScopeは、厚労省通知・ガイドライン・添付文書・診療報酬告示などの一次資料と、院内マニュアル・契約書・SLAなどの実務文書を突合し、抜け漏れや不整合を根拠付きで提示するツールです。単なる検索エンジンではなく、「差分レポート＋不足項目＋根拠引用」を出力します。
+                        GuideScopeは、厚労省通知・ガイドライン・添付文書・診療報酬告示などの一次資料を対象に、LLMへ投入する検索プロンプトを生成するツールです。単なる検索キーワード列挙ではなく、国内医療AIガイドラインの探索に必要な観点を整理した形で、Google Gemini・ChatGPT・Claude等ですぐ使える入力文を出力します。
                     </p>
 
                     <h2 class="text-xl md:text-2xl font-bold text-brand-black mb-4 mt-10">コア機能：文書×文書の突合・検証</h2>
                     <p>
-                        GuideScopeの中核は、公的な一次資料と院内の実務文書——いずれも「文書」同士を突合する技術です。外部システム連携なしで即座に導入でき、差分・不足・根拠を提示します。
+                        現在提供中のMVPでは、国内の医療AI関連ガイドラインを探索するためのLLM向け検索プロンプト生成をコア機能として提供しています。公的な一次資料を効率よくたどる入口を整えつつ、将来的には公的文書と院内実務文書を並べて差分・不足・根拠を提示する比較機能へ拡張する計画です。
                     </p>
                     <ul class="space-y-4 mb-6 list-none pl-0">
                         <li class="flex gap-3 items-start">
                             <span class="shrink-0 w-6 h-6 rounded-full bg-flame text-white flex items-center justify-center text-xs font-bold mt-0.5">1</span>
-                            <span><strong class="text-brand-black">院内マニュアルのガイドライン準拠確認</strong> — 感染対策・医療安全などのガイドライン改定時に、院内マニュアルとの差分を自動検出。更新が必要な箇所を根拠付きで提示します。</span>
+                            <span><strong class="text-brand-black">LLM向け検索プロンプト生成</strong> — 国内の医療AI関連ガイドラインや通知を探すための検索プロンプトを生成し、Google Gemini・ChatGPT・Claude等へそのまま投入できます。</span>
                         </li>
                         <li class="flex gap-3 items-start">
                             <span class="shrink-0 w-6 h-6 rounded-full bg-flame text-white flex items-center justify-center text-xs font-bold mt-0.5">2</span>
-                            <span><strong class="text-brand-black">電カル・システム契約チェック</strong> — 3省2ガイドラインとベンダー契約書・SLAを照合し、セキュリティ要件や責任分界の充足状況を可視化。契約更新時の判断材料を提供します。</span>
+                            <span><strong class="text-brand-black">次フェーズに向けた比較基盤</strong> — 一次資料と院内マニュアル、契約書、SLAなどの実務文書を突合し、差分や不足項目を根拠付きで返す比較機能の土台を継続開発しています。</span>
                         </li>
                     </ul>
 
-                    <h2 class="text-xl md:text-2xl font-bold text-brand-black mb-4 mt-10">発展的な活用シーン</h2>
+                    <h2 class="text-xl md:text-2xl font-bold text-brand-black mb-4 mt-10">ロードマップ（今後の展開）</h2>
                     <p>
-                        以下の活用シーンは、文書突合に加えてレセプトデータ・人事台帳・電子カルテなどとの連携技術を並走開発することで実現を目指します。
+                        以下の活用シーンは、文書突合に加えてレセプトデータ・人事台帳・電子カルテなどとの連携技術を並走開発することで、今後のロードマップとして実現を目指します。
                     </p>
                     <ul class="space-y-4 mb-6 list-none pl-0">
                         <li class="flex gap-3 items-start">
@@ -187,12 +188,12 @@
                         </li>
                     </ul>
 
-                    <h2 class="text-xl md:text-2xl font-bold text-brand-black mb-4 mt-10">今後の展望</h2>
+                    <h2 class="text-xl md:text-2xl font-bold text-brand-black mb-4 mt-10">提供状況とロードマップ</h2>
                     <p>
-                        GuideScopeは、Cursorversが提供する医療AIガバナンスサービスの一環として位置づけられます。まずは院内マニュアルGL準拠確認とシステム契約チェックからMVPを提供し、段階的に対応領域を拡大してまいります。
+                        GuideScopeは、Cursorversが提供する医療AIガバナンスサービスの一環として、まずは https://cursorvers.jp/tools/guidescope/ でLLM向け検索プロンプト生成ツールとしてMVPを提供中です。国内の医療AI関連ガイドラインを探索する初動を支援し、Google Gemini・ChatGPT・Claude等での利用を想定しています。
                     </p>
                     <p>
-                        開発状況やリリーススケジュールについては、本ページおよびCursorvers公式サイトにてお知らせいたします。
+                        次フェーズでは、一次資料と院内実務文書の突合、診療報酬改定の影響分析、施設基準確認、適時調査準備などを順次ロードマップに載せ、比較・検証まで踏み込んだ支援へ拡張していきます。
                     </p>
                 </div>
 
@@ -221,6 +222,9 @@
 
                 <!-- CTA Buttons -->
                 <div class="mt-12 flex flex-col sm:flex-row gap-4">
+                    <a href="https://cursorvers.jp/tools/guidescope/" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center px-8 py-4 sm:min-w-[240px] bg-flame text-white font-bold rounded-full hover:bg-brand-black transition text-base">
+                        GuideScope を試す ↗
+                    </a>
                     <a href="../news.html" class="inline-flex items-center justify-center px-8 py-4 sm:min-w-[240px] bg-brand-black text-white font-bold rounded-full hover:bg-flame transition text-base cta-balanced-back">
                         <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 19l-7-7 7-7"/></svg>
                         お知らせ一覧に戻る
@@ -258,6 +262,7 @@
         <li><a href="../message.html">創業者メッセージ</a></li>
         <li><a href="../news.html">お知らせ</a></li>
         <li><a href="https://cursorvers.jp/" target="_blank" rel="noopener">Cursorvers.edu ↗</a></li>
+        <li><a href="https://cursorvers.jp/tools/guidescope/" target="_blank" rel="noopener noreferrer">GuideScope ↗</a></li>
         <li><a href="https://cursorvers.jp/tools/auditscope/" target="_blank" rel="noopener">AuditScope ↗</a></li>
       </ul>
     </div>

--- a/news/2026-02-10-guidescope.html
+++ b/news/2026-02-10-guidescope.html
@@ -34,6 +34,7 @@
     <meta property="article:published_time" content="2026-02-10">
 
     <link rel="stylesheet" href="../dist/tailwind.min.css?v=385a39f">
+    <link rel="stylesheet" href="../assets/css/renewal.css?v=20260421i">
     <!-- System fonts: no external loading needed -->
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif; background: #fff; color: #1d1d1f; }

--- a/news/2026-02-16-ggen-partnership.html
+++ b/news/2026-02-16-ggen-partnership.html
@@ -34,6 +34,7 @@
     <meta property="article:published_time" content="2026-02-16">
 
     <link rel="stylesheet" href="../dist/tailwind.min.css?v=385a39f">
+    <link rel="stylesheet" href="../assets/css/renewal.css?v=20260421i">
     <!-- System fonts: no external loading needed -->
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif; background: #fff; color: #1d1d1f; }

--- a/news/2026-02-18-health-isac-japan.html
+++ b/news/2026-02-18-health-isac-japan.html
@@ -34,6 +34,7 @@
     <meta property="article:published_time" content="2026-02-18">
 
     <link rel="stylesheet" href="../dist/tailwind.min.css?v=385a39f">
+    <link rel="stylesheet" href="../assets/css/renewal.css?v=20260421i">
     <!-- System fonts: no external loading needed -->
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif; background: #fff; color: #1d1d1f; }

--- a/news/2026-03-02-hospital-ai-implementation.html
+++ b/news/2026-03-02-hospital-ai-implementation.html
@@ -34,6 +34,7 @@
     <meta property="article:published_time" content="2026-03-02">
 
     <link rel="stylesheet" href="../dist/tailwind.min.css?v=385a39f">
+    <link rel="stylesheet" href="../assets/css/renewal.css?v=20260421i">
     <!-- System fonts: no external loading needed -->
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif; background: #fff; color: #1d1d1f; }


### PR DESCRIPTION
## Summary
直近の Deploy workflow が Node.js 20 deprecation 警告を出していた:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

対象アクション: `actions/configure-pages@v5`, `actions/upload-artifact` (configure-pages/deploy-pages 内の pinned SHA), `actions/deploy-pages@v4`

## 変更
- `.github/workflows/deploy.yml`:
  - top-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` を追加（公式 opt-in）
  - `node-version: "20"` → `"24"` に bump (build + smoke-test 2箇所)
- `.github/workflows/lighthouse.yml`:
  - 同じく top-level env opt-in
  - `node-version: '20'` → `'24'`

他 workflow (`backup.yml`, `fugue-*.yml`) は外部 reusable workflow に委譲 or node-version 未固定のため変更なし。

## 検証
- `python3 -c "import yaml; yaml.safe_load(...)"` → OK
- `actionlint` → info レベルの既存 shellcheck warning のみ (line 40/52、今回変更と無関係)

## Test plan
- [ ] この PR の Lighthouse CI check が Node 24 で緑
- [ ] merge 後の Deploy to GitHub Pages が Node 24 runtime で走り、Node 20 deprecation annotation が消える
- [ ] smoke-test (Playwright against production) が Node 24 で通る

## Reference
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)