### PR TITLE
fix(sw): bypass SW cache for videos + bump CACHE_VERSION (iPhone stale hero fix)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker for Cursorvers PWA
-const CACHE_VERSION = '1.0.2'; // Updated: 2026-04-13 - Typography cache refresh
+const CACHE_VERSION = '1.0.3'; // Updated: 2026-04-25 - Invalidate hero video cache after compression swap (PR #15)
 const CACHE_NAME = `cursorvers-v${CACHE_VERSION}`;
 
 // Static assets - Cache First
@@ -75,6 +75,12 @@ self.addEventListener('fetch', (event) => {
   }
 
   // Cache First for static assets
+  // Bypass Service Worker cache for media files.
+  if (url.pathname.endsWith('.mp4') || url.pathname.endsWith('.webm') || url.pathname.endsWith('.mov') || url.pathname.endsWith('.m4v') || url.pathname.endsWith('.ogg')) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request)
       .then((response) => {


### PR DESCRIPTION
## Summary
- Fix for iPhone Safari serving the old (pre-PR #15) hero video even though origin/Fastly already serve the new compressed bytes.
- Root cause: `sw.js` Cache First strategy + `CACHE_VERSION` not bumped since 2026-04-13 → SW-cached 7.9 MB mobile video stayed resident across sessions.

## Fixes
1. **`CACHE_VERSION` bump** `1.0.2` → `1.0.3` so the `activate` handler purges the stale cache entry on next visit.
2. **Media cache bypass** — `.mp4 / .webm / .mov / .m4v / .ogg` now skip the SW cache entirely and go straight to network. Prevents the regression from recurring on future video swaps and keeps large binaries out of the SW quota.

Existing HTML Network-First and static (css/icons/webp) Cache-First branches unchanged.

## Verification plan
- [ ] After merge + Pages deploy, iPhone Safari hard-reload → new hero video (4.81 MB desktop / 1.74 MB mobile) is served
- [x] Origin already serves new bytes (verified in PR #15 via `curl -sI https://cursorvers.com/hero_wave*.mp4` → content-length 4812967 / 1736202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)