### PR TITLE
fix(hero): cache-bust video URLs (?v=20260425) to force iPhone stale-SW bypass

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,8 +765,8 @@
         <!-- Video Background - EXACTLY same as edu -->
         <div class="hero-video-container">
             <video class="hero-video" autoplay muted loop playsinline poster="hero_wave_poster.jpg">
-                <source src="hero_wave_mobile.mp4" type="video/mp4" media="(max-width: 767px)">
-                <source src="hero_wave.mp4" type="video/mp4" media="(min-width: 768px)">
+                <source src="hero_wave_mobile.mp4?v=20260425" type="video/mp4" media="(max-width: 767px)">
+                <source src="hero_wave.mp4?v=20260425" type="video/mp4" media="(min-width: 768px)">
                 <source src="https://videos.pexels.com/video-files/4878910/4878910-uhd_2560_1440_24fps.mp4" type="video/mp4">
             </video>
             <div class="hero-overlay"></div>


### PR DESCRIPTION
## Why
Follow-up to PR #15 (new hero) + PR #16 (SW bypass fix). iPhones that visited cursorvers.com **before** PR #15 still have the old 7.9 MB `hero_wave_mobile.mp4` pinned in the SW 1.0.2 Cache-First cache. Until the Fastly edge sw.js TTL (14400s) expires naturally, the new SW 1.0.3 (with .mp4 bypass) can't activate on those devices, so the old SW keeps intercepting and serving the stale video from cache.

## Fix
Append `?v=20260425` to the two hero `<source>` URLs in `index.html`. The query string makes the request URL a **different cache key** under the old SW, so `caches.match()` misses, falls through to network, and the iPhone picks up the new compressed video immediately.

- `hero_wave_mobile.mp4` → `hero_wave_mobile.mp4?v=20260425`
- `hero_wave.mp4` → `hero_wave.mp4?v=20260425`

`index.html` is Network-First in the SW fetch handler, so iPhones get the updated `<source>` tags on the next page load without needing SW update/activation.

## Test plan
- [ ] After merge + Pages deploy, iPhone re-visit cursorvers.com → new compressed video appears
- [ ] Desktop Chrome DevTools Network tab shows `hero_wave.mp4?v=20260425` with content-length 4,812,967

🤖 Generated with [Claude Code](https://claude.com/claude-code)