### PR TITLE
fix(pwa): auto-purge legacy SW cache on registration (stuck iPhone recovery)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1765,6 +1765,13 @@
                     navigator.serviceWorker.register('/sw.js')
                         .then((registration) => {
                             console.log('[PWA] Service Worker registered:', registration.scope);
+                            // One-time cleanup for the PR #15 hero video cache-swap.
+                            registration.update().catch(() => {});
+                            if ('caches' in window) {
+                                caches.keys().then(keys => keys
+                                    .filter(k => k.startsWith('cursorvers-v') && k !== 'cursorvers-v1.0.3')
+                                    .forEach(k => caches.delete(k)));
+                            }
                         })
                         .catch((error) => {
                             console.log('[PWA] Service Worker registration failed:', error);


### PR DESCRIPTION
## Why
Follow-up to PR #15/#16/#17. Devices that visited cursorvers.com before PR #15 still have the old 1.0.2 Service Worker active and the 7.9 MB \`hero_wave_mobile.mp4\` pinned in its cache. Even with the \`?v=20260425\` cache-bust (PR #17), some iPhones keep showing the old video because the stale SW intercepts before the new one can activate.

## Fix
Add a one-time cleanup inside the existing \`navigator.serviceWorker.register()\` success callback in \`index.html\`:

1. \`registration.update()\` — forces an immediate SW update check. Browsers bypass the HTTP cache for \`sw.js\` during update checks (spec default), so the Fastly edge cache doesn't prevent the new 1.0.3 SW from being picked up.
2. \`caches.keys()\` — deletes every \`cursorvers-v*\` Cache Storage entry that is not \`cursorvers-v1.0.3\`. This immediately purges the 7.9 MB video pinned in the 1.0.2 cache the moment the visitor loads the new HTML.

Only ships in new HTML, so no impact on visitors already fully on 1.0.3. Idempotent — safe to re-run.

## Diff (1 file, +7 lines inside existing SW registration block)
See commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)