### PR TITLE
fix(cache): bump URL query + SW version to break iPhone stale cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,8 +765,8 @@
         <!-- Video Background - EXACTLY same as edu -->
         <div class="hero-video-container">
             <video class="hero-video" autoplay muted loop playsinline poster="hero_wave_poster.jpg">
-                <source src="hero_wave_mobile.mp4?v=20260425" type="video/mp4" media="(max-width: 767px)">
-                <source src="hero_wave.mp4?v=20260425" type="video/mp4" media="(min-width: 768px)">
+                <source src="hero_wave_mobile.mp4?v=20260425b" type="video/mp4" media="(max-width: 767px)">
+                <source src="hero_wave.mp4?v=20260425b" type="video/mp4" media="(min-width: 768px)">
                 <source src="https://videos.pexels.com/video-files/4878910/4878910-uhd_2560_1440_24fps.mp4" type="video/mp4">
             </video>
             <div class="hero-overlay"></div>

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker for Cursorvers PWA
-const CACHE_VERSION = '1.0.4'; // Updated: 2026-04-25 - Force navigate clients to refresh stuck iPhone tabs after PR #15
+const CACHE_VERSION = '1.0.5'; // Updated: 2026-04-25 - URL query bump to force iPhone stale cache miss after PR #20 source swap
 const CACHE_NAME = `cursorvers-v${CACHE_VERSION}`;
 
 // Static assets - Cache First


### PR DESCRIPTION
## Summary

PR #20 で `hero_wave_mobile.mp4` を正しいソースに差し替えたが、iPhone Safari 側で古い SW (1.0.3 以前で installed 済) が `hero_wave_mobile.mp4?v=20260425` を URL key として stale cache していたため、新ファイルが反映されず PC 版と異なる動画が表示されていた。

URL query を bump して旧 SW cache key を miss させ、PR #16 の media bypass + PR #19 の clients.claim+navigate と組み合わせて自動的に新動画へ切り替える。

## Changes

- `index.html` (line 768-769): `?v=20260425` → `?v=20260425b` (両 `<source>`)
- `sw.js` (line 2): `CACHE_VERSION = '1.0.4'` → `'1.0.5'`

`index.html` 本文と sw.js のロジックは無改変、純粋に cache key bump のみ。

## Test plan

- [ ] Pages deploy 後 `curl -s https://cursorvers.com/index.html | grep '?v='` で `?v=20260425b` 確認
- [ ] `curl -s https://cursorvers.com/sw.js | grep CACHE_VERSION` で `'1.0.5'` 確認
- [ ] iPhone Safari リロード後、PC と同じ波動画が表示される
- [ ] PR #16/#17/#18/#19/#20 の挙動に regression が無い

🤖 Generated with [Claude Code](https://claude.com/claude-code)