### PR TITLE
fix(cache): URL key bump v=20260425d to remediate CF cache poisoning

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,8 +765,8 @@
         <!-- Video Background - EXACTLY same as edu -->
         <div class="hero-video-container">
             <video class="hero-video" autoplay muted loop playsinline poster="hero_wave_poster.jpg">
-                <source src="hero_wave_mobile.mp4?v=20260425c" type="video/mp4" media="(max-width: 767px)">
-                <source src="hero_wave.mp4?v=20260425c" type="video/mp4" media="(min-width: 768px)">
+                <source src="hero_wave_mobile.mp4?v=20260425d" type="video/mp4" media="(max-width: 767px)">
+                <source src="hero_wave.mp4?v=20260425d" type="video/mp4" media="(min-width: 768px)">
                 <source src="https://videos.pexels.com/video-files/4878910/4878910-uhd_2560_1440_24fps.mp4" type="video/mp4">
             </video>
             <div class="hero-overlay"></div>

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Service Worker for Cursorvers PWA
-const CACHE_VERSION = '1.0.6'; // Updated: 2026-04-25 - mobile video unified with desktop content; URL key bump to ?v=20260425c
+const CACHE_VERSION = '1.0.7'; // Updated: 2026-04-25 - URL key bump to ?v=20260425d to remediate Cloudflare cache poisoning of v=20260425c
 const CACHE_NAME = `cursorvers-v${CACHE_VERSION}`;
 
 // Static assets - Cache First


### PR DESCRIPTION
## Summary
- PR #23 で `?v=20260425c` URL キーで mobile/desktop video を統一したが、私の **pre-deploy curl probe** が deploy 前に Cloudflare edge cache を旧コンテンツで populate (cache poisoning)
- 結果: `hero_wave_mobile.mp4?v=20260425c` が cf-cache-status HIT で stale 1.30MB を配信し続ける
- 修復: URL key を `?v=20260425d` に再 bump (新規 CF キー強制) + SW CACHE_VERSION 1.0.6 → 1.0.7

## Root cause
| URL | cf-cache-status | size | 状態 |
|---|---|---|---|
| `hero_wave_mobile.mp4?v=20260425c` | HIT | 1,297,878 B | 旧 (PR #22 timestamp で凍結) |
| `hero_wave.mp4?v=20260425c` | HIT | 4,759,495 B | 正 (PR #23 timestamp) |
| 直接 GH Pages (random query) | MISS→HIT | 4,759,495 B | 正 ✓ |

CF が `?v=20260425c` の poisoned key で stale を配信していた。Origin は健全。

## Fix
- `index.html`: `?v=20260425c` → `?v=20260425d` (lines 768-769)
- `sw.js`: `CACHE_VERSION = '1.0.7'`

## Operational learning
**deploy 前の pre-probe は cache poisoning を起こす**。今後 `?v=XXX` 系の検証は post-deploy のみ、もしくは random query string で代替する。

## Test plan
- [x] `index.html` `?v=20260425d` × 2
- [x] `sw.js` CACHE_VERSION 1.0.7
- [ ] post-merge: GH Pages live で `?v=20260425d` が **MISS→HIT で 4,759,495 B** を返すこと (pre-probe 禁止)
- [ ] iPhone Safari で実機確認 (Service Worker 自動更新後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)