### PR TITLE
feat(ci): add media-asset-policy lint to prevent iOS Safari video cache regression

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -211,6 +211,51 @@ module.exports = {
 
 ---
 
+## メディア資産デプロイ — iOS Safari cache 落とし穴
+
+PR #15-#27 (2026-04-25) の実体験から得た教訓。同種の動画/オーディオ差し替えタスクで繰り返さないこと。
+
+### 根本原因
+
+iOS WebKit の `<video>` / `<audio>` は **AVPlayer system-level cache** が **path-keyed**。query string (`?v=20260425`) は cache key に含まれないため、`?v=` bump では iPhone Safari に新しいアセットが届かない。PC Safari は HTTP cache で動くため query bump が効き、iPhone だけ古い動画を表示し続ける非対称が発生する。
+
+### 5 つの予防ルール (CI 強制対象)
+
+これらは `.github/workflows/media-asset-policy.yml` + `scripts/lint-media-asset-policy.mjs` で PR 時に自動検証される。違反で CI fail。
+
+- **R1: ローカル video/audio に `?v=` query を付けない**
+  - 差し替えたければ file path そのものを rename する (`git mv hero.mp4 hero_v2.mp4`)
+  - external URL (pexels.com 等) の query token は対象外
+- **R2: video/audio file を modify せず、rename (add + delete) する**
+  - `git diff --name-status` で `M` ステータスの video は fail
+  - `R` (rename) または `A`/`D` ペアは OK
+- **R3: service worker (sw.js) は video 拡張子を cache bypass する**
+  - `fetch(event.request)` を video 拡張子に対して通す pattern が無ければ warn
+  - これが欠けると SW cache で古い動画が延命する
+- **R4: pre-deploy で `curl https://cursorvers.com/...` で疎通確認しない**
+  - Cloudflare CDN の cache を probe が poisoning して古い asset を pin してしまう
+  - smoke-test の post-deploy URL probe は `# probe-after-deploy` マーカーで許可
+- **R5: `<video>` 子 `<source>` は mobile-first 順 (`max-width` → `min-width`)**
+  - iOS は最初に match した source を選ぶため、PC 用が先にあるとモバイルで PC 版が再生される
+
+### 検証手順 (必須)
+
+1. CI (`media-asset-policy` job) が PASS していること
+2. **iPhone 実機** (Safari) で反映確認 — Playwright / Lighthouse / PC Safari は build-id しか見ないので不十分
+3. 反映しない場合、`?v=` を追加しない。3 回 query bump が無効なら即座に path rename に切り替える (PR #15-#27 の 5 回失敗を繰り返さない)
+
+### 例外 override
+
+緊急時のみ、PR に `media-asset-policy-ack` label を付けると全ルールが warning にダウングレードされる。label 付与は reviewer 合意後に限り、PR description に override 理由を必ず記す。
+
+### 関連 PR (学習源)
+
+- PR #15-#26: `?v=` query bump を 5 回試行し全敗 (iPhone 到達失敗)
+- PR #27: `git mv hero_wave.mp4 → hero_v6_pc.mp4` + `<source>` から query 完全削除 + sw.js bump で即時反映成功
+- PR #28: 本ルール群を CI 強制化 (`media-asset-policy.yml`)
+
+---
+
 ## Platform 連携ルール
 
 **システム変更時は `Cursorvers_Platform/docs/system-architecture.md` を更新すること。**

--- a/.github/workflows/media-asset-policy.yml
+++ b/.github/workflows/media-asset-policy.yml
@@ -1,0 +1,42 @@
+name: Media Asset Policy
+on:
+  pull_request:
+    paths:
+      - '**/*.html'
+      - '**/*.mp4'
+      - '**/*.webm'
+      - '**/*.mov'
+      - '**/*.m4v'
+      - '**/*.ogv'
+      - 'sw.js'
+      - 'scripts/lint-media-asset-policy.mjs'
+      - '.github/workflows/media-asset-policy.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  media-asset-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for git diff)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install lint deps
+        run: npm ci
+
+      - name: Run media asset policy lint
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+        run: node scripts/lint-media-asset-policy.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^6.5.2",
         "@playwright/test": "^1.57.0",
+        "parse5": "^7.2.1",
         "tailwindcss": "^3.4.17"
       }
     },
@@ -267,6 +268,19 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -547,6 +561,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-parse": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.5.2",
     "@playwright/test": "^1.57.0",
+    "parse5": "^7.2.1",
     "tailwindcss": "^3.4.17"
   }
 }

--- a/scripts/lint-media-asset-policy.mjs
+++ b/scripts/lint-media-asset-policy.mjs
@@ -1,0 +1,252 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import * as parse5 from 'parse5';
+
+const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mov', '.m4v', '.ogv'];
+const EXCLUDED_DIRS = new Set(['.git', 'node_modules', '_site', 'dist']);
+const POLICY_REF = '.claude/CLAUDE.md "メディア資産デプロイ — iOS Safari cache 落とし穴"';
+
+const findings = [];
+
+function isExternalUrl(value) {
+  return /^https?:\/\//i.test(value);
+}
+
+function videoExtensionFromPathname(value) {
+  const withoutHash = value.split('#')[0];
+  const pathname = withoutHash.split('?')[0].toLowerCase();
+  return VIDEO_EXTENSIONS.find((ext) => pathname.endsWith(ext));
+}
+
+function addFinding(rule, level, file, line, message) {
+  findings.push({
+    rule,
+    level,
+    file,
+    line: line || 1,
+    message: `Rule ${rule}: ${message} See ${POLICY_REF}.`,
+  });
+}
+
+function walkFiles(dir, predicate, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (EXCLUDED_DIRS.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, predicate, acc);
+    } else if (entry.isFile() && predicate(fullPath)) {
+      acc.push(fullPath);
+    }
+  }
+  return acc;
+}
+
+function relativePath(filePath) {
+  return path.relative(process.cwd(), filePath) || filePath;
+}
+
+function getAttr(node, name) {
+  return node.attrs?.find((attr) => attr.name.toLowerCase() === name.toLowerCase())?.value;
+}
+
+function getAttrLine(node, name) {
+  return node.sourceCodeLocation?.attrs?.[name]?.startLine || node.sourceCodeLocation?.startLine || 1;
+}
+
+function visit(node, callback) {
+  callback(node);
+  for (const child of node.childNodes || []) {
+    visit(child, callback);
+  }
+}
+
+function lintHtmlSources() {
+  const htmlFiles = walkFiles(process.cwd(), (file) => file.toLowerCase().endsWith('.html'));
+
+  for (const file of htmlFiles) {
+    const rel = relativePath(file);
+    const html = readFileSync(file, 'utf8');
+    const document = parse5.parse(html, { sourceCodeLocationInfo: true });
+
+    visit(document, (node) => {
+      if (node.nodeName === 'source') {
+        const src = getAttr(node, 'src');
+        if (!src || isExternalUrl(src)) return;
+
+        if (videoExtensionFromPathname(src) && src.includes('?')) {
+          addFinding(
+            'R1',
+            'error',
+            rel,
+            getAttrLine(node, 'src'),
+            `Local video source "${src}" uses a query string. iOS Safari AVPlayer cache is path-keyed, so rename the file path instead, e.g. "git mv old.mp4 old_v2.mp4" and update <source src="old_v2.mp4">.`
+          );
+        }
+      }
+
+      if (node.nodeName === 'video') {
+        lintVideoSourceOrder(node, rel);
+      }
+    });
+  }
+}
+
+function lintVideoSourceOrder(videoNode, rel) {
+  const sources = (videoNode.childNodes || []).filter((child) => child.nodeName === 'source');
+  const sourceMeta = sources.map((source) => ({
+    node: source,
+    media: getAttr(source, 'media') || '',
+    src: getAttr(source, 'src') || '',
+  }));
+
+  for (let index = 0; index < sourceMeta.length; index += 1) {
+    const current = sourceMeta[index];
+    if (!/min-width/i.test(current.media)) continue;
+
+    const laterMax = sourceMeta.slice(index + 1).find((candidate) => /max-width/i.test(candidate.media));
+    if (laterMax) {
+      addFinding(
+        'R5',
+        'error',
+        rel,
+        getAttrLine(current.node, 'media'),
+        `Desktop/min-width source "${current.src || current.media}" appears before mobile/max-width source "${laterMax.src || laterMax.media}". Put mobile max-width <source> first, then desktop min-width.`
+      );
+    }
+  }
+}
+
+function resolveDiffRange() {
+  const envBase = process.env.PR_BASE_SHA;
+  const envHead = process.env.PR_HEAD_SHA;
+  if (envBase && envHead) return { base: envBase, head: envHead };
+
+  const candidates = ['origin/main', 'main', 'origin/master', 'master'];
+  for (const candidate of candidates) {
+    try {
+      const base = execFileSync('git', ['merge-base', 'HEAD', candidate], { encoding: 'utf8' }).trim();
+      if (base) return { base, head: 'HEAD' };
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return null;
+}
+
+function lintVideoModifyWithoutRename() {
+  const range = resolveDiffRange();
+  if (!range) {
+    addFinding(
+      'R2',
+      'warning',
+      'git',
+      1,
+      'Could not resolve PR_BASE_SHA/PR_HEAD_SHA or a local merge-base; skipped video modify-without-rename diff check.'
+    );
+    return;
+  }
+
+  let output = '';
+  try {
+    output = execFileSync('git', ['diff', '--name-status', `${range.base}...${range.head}`], { encoding: 'utf8' });
+  } catch (error) {
+    addFinding('R2', 'error', 'git', 1, `Failed to run git diff for ${range.base}...${range.head}: ${error.message}`);
+    return;
+  }
+
+  for (const line of output.split('\n').filter(Boolean)) {
+    const fields = line.split('\t');
+    const status = fields[0];
+    const file = fields.at(-1);
+    if (status === 'M' && file && videoExtensionFromPathname(file)) {
+      addFinding(
+        'R2',
+        'error',
+        file,
+        1,
+        `Video file "${file}" was modified in place. iOS Safari may keep the old path-keyed media cache; rename instead, e.g. "git mv ${file} ${file.replace(/(\.[^.]+)$/i, '_v2$1')}" and update HTML references.`
+      );
+    }
+  }
+}
+
+function lintServiceWorkerBypass() {
+  const swPath = path.join(process.cwd(), 'sw.js');
+  if (!existsSync(swPath)) return;
+
+  const source = readFileSync(swPath, 'utf8');
+  const hasVideoExtensionCheck = VIDEO_EXTENSIONS.some((ext) => source.toLowerCase().includes(ext));
+  const hasFetchBypass = /fetch\s*\(\s*event\.request\s*\)/.test(source);
+
+  if (!hasVideoExtensionCheck || !hasFetchBypass) {
+    addFinding(
+      'R3',
+      'warning',
+      'sw.js',
+      1,
+      'Service Worker should bypass cache for video paths with "event.respondWith(fetch(event.request))" near mp4/webm/mov/m4v/ogv handling.'
+    );
+  }
+}
+
+function lintCursorversCurlProbe() {
+  const targetExtensions = new Set(['.sh', '.yml', '.mjs', '.js']);
+  const files = walkFiles(process.cwd(), (file) => targetExtensions.has(path.extname(file).toLowerCase()));
+
+  for (const file of files) {
+    const rel = relativePath(file);
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, index) => {
+      if (!/curl\b.*https:\/\/cursorvers\.com/i.test(line)) return;
+      if (line.includes('# probe-after-deploy')) return;
+      addFinding(
+        'R4',
+        'warning',
+        rel,
+        index + 1,
+        'Found a curl probe against https://cursorvers.com. Avoid pre-deploy live URL probes that can poison CDN 404 cache, or mark an allowed post-deploy probe with "# probe-after-deploy".'
+      );
+    });
+  }
+}
+
+function hasOverrideLabel() {
+  try {
+    const labels = JSON.parse(process.env.PR_LABELS || '[]');
+    return Array.isArray(labels) && labels.some((label) => label?.name === 'media-asset-policy-ack');
+  } catch {
+    addFinding('Override', 'warning', 'PR_LABELS', 1, 'Could not parse PR_LABELS JSON; media-asset-policy-ack override was not applied.');
+    return false;
+  }
+}
+
+function emitFindings(override) {
+  let errorCount = 0;
+  let warningCount = 0;
+
+  for (const finding of findings) {
+    const annotationLevel = finding.level === 'error' && !override ? 'error' : 'warning';
+    if (finding.level === 'error') errorCount += 1;
+    if (finding.level === 'warning' || annotationLevel === 'warning') warningCount += 1;
+
+    const output = `${annotationLevel === 'error' ? '::error' : '::warning'} file=${finding.file},line=${finding.line}::${finding.message}`;
+    if (annotationLevel === 'error') {
+      console.error(output);
+    } else {
+      console.warn(output);
+    }
+  }
+
+  const status = errorCount === 0 ? 'PASS' : override ? 'PASS_WITH_OVERRIDE' : 'FAIL';
+  console.log(`Media Asset Policy summary: ${status}; errors=${errorCount}; warnings=${warningCount}; override=${override ? 'media-asset-policy-ack' : 'none'}`);
+
+  if (errorCount > 0 && !override) process.exitCode = 1;
+}
+
+lintHtmlSources();
+lintVideoModifyWithoutRename();
+lintServiceWorkerBypass();
+lintCursorversCurlProbe();
+emitFindings(hasOverrideLabel());


### PR DESCRIPTION
## Summary
This PR adds a Media Asset Policy CI workflow so the PR #15-#27 hero-video incident cannot recur silently.

The key lesson from PR #27 was that iOS Safari video freshness is path-keyed: repeated query bumps and Service Worker/cache-version changes did not reliably refresh the mobile video, while renaming the media path did.

## PR #15-#27 learnings referenced
- PR #15 introduced the compressed hero video swap.
- PR #16 and #19 improved Service Worker handling, but SW behavior alone was not enough for iPhone Safari.
- PR #17, #21, and #24 tried URL query/cache key bumps; the PR #27 conclusion was that query bumping is not reliable for iOS AVPlayer media cache.
- PR #22 addressed stale poster cleanup, reinforcing that poster/media assets should move together.
- PR #23-#26 continued mobile/desktop source correction, showing source order and mobile-specific validation matter.
- PR #27 resolved the regression by renaming video/poster paths to hero_v6_* and documenting path rename as the durable rule.

## Rules enforced
1. R1: fail local video <source> URLs that use ?v= query cache busting; require path rename instead.
2. R2: fail modified-in-place video files in PR diffs; allow add/delete pairs and git renames.
3. R3: warn when sw.js lacks a Service Worker cache bypass pattern for video media.
4. R4: warn on curl probes to https://cursorvers.com unless explicitly marked as # probe-after-deploy.
5. R5: fail <video> source order where desktop min-width sources appear before mobile max-width sources.

## Override procedure
Apply the PR label `media-asset-policy-ack` only after the reviewer has explicitly accepted the media-cache risk. With the label present, all lint findings are still logged as GitHub annotations, but fail-level rules are downgraded to warnings and the workflow exits 0.

## Non-functional notes
- Scope is isolated to a new workflow and script; existing deploy.yml, lighthouse.yml, and backup.yml are untouched.
- HTML parsing uses parse5 AST location data rather than grep, so comments are naturally ignored and annotations point to the offending source line.
- The workflow uses PR base/head SHAs so release branches and non-main PR bases can be linted without assuming a fixed branch name.

## Test plan
- [x] npm install --save-dev parse5
- [x] npm ci
- [x] node scripts/lint-media-asset-policy.mjs -> PASS
- [x] Temporary index.html local video source ?v=foo -> R1 FAIL, then reverted
