### PR TITLE
ci: restore Forbidden Words Gate workflow

### DIFF
--- a/.github/workflows/forbidden-words-gate.yml
+++ b/.github/workflows/forbidden-words-gate.yml
@@ -1,0 +1,88 @@
+name: Forbidden Words Gate
+
+on:
+  pull_request:
+    paths:
+      - index.html
+      - services.html
+      - gov-lead.html
+      - contact.html
+      - news/**/*.html
+  push:
+    branches:
+      - main
+    paths:
+      - index.html
+      - services.html
+      - gov-lead.html
+      - contact.html
+      - news/**/*.html
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Scan forbidden marketing words
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          targets=(
+            "index.html"
+            "services.html"
+            "gov-lead.html"
+            "contact.html"
+          )
+
+          if [ -d news ]; then
+            while IFS= read -r -d '' file; do
+              targets+=("$file")
+            done < <(find news -type f -name '*.html' -print0)
+          fi
+
+          patterns=(
+            "断罪"
+            "裁く"
+            "違反"
+            "告発"
+            "暴く"
+            "本監査"
+            "運用後監査"
+            "年次監査"
+            "監査レビュー"
+            "監査観点"
+            "監査範囲"
+            "監査報告"
+            "監査準備"
+            "監査スケジュール"
+            "監査の流れ"
+          )
+
+          existing_targets=()
+          for file in "${targets[@]}"; do
+            if [ -f "$file" ]; then
+              existing_targets+=("$file")
+            fi
+          done
+
+          if [ "${#existing_targets[@]}" -eq 0 ]; then
+            echo "OK: no forbidden words detected."
+            exit 0
+          fi
+
+          failed=0
+          for pattern in "${patterns[@]}"; do
+            if grep -F -n -- "$pattern" "${existing_targets[@]}"; then
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::Forbidden marketing wording detected. Do not use the listed marketing phrases. Standalone 監査 is allowed in CLASS B technical/legal contexts such as 監査ログ, 税務監査, 法定監査, セキュリティ監査."
+            exit 1
+          fi
+
+          echo "OK: no forbidden words detected."


### PR DESCRIPTION
## 目的
監査→アセスメント rename を強制する CI ゲート `forbidden-words-gate.yml` を復活。

## 経緯
- `242a2b5` で導入(PR#10)→ PR#11 で全 revert により巻き込み消失 → PR#13 の rename でも未復活。
- live `origin/main` と作業用クローン `web/inc` の双方に不在、`git branch -r --contains 242a2b5` は空。
- 退役予定の旧 `cursorvers-inc` ローカルクローン(branch `feat/lp-rebuild-20260424`)に**のみ**存置していた唯一の unique 成果物を救済。

## 内容
- `.github/workflows/forbidden-words-gate.yml`(88行)を追加。
- PR/push 時、対象ファイル(index/services/gov-lead/contact.html + news/**/*.html)で禁止語が出ると fail。
- 単独「監査」は許容(CLASS B: 監査ログ/税務監査/法定監査/セキュリティ監査)。

## 安全性
- **現行 origin/main の対象ファイルに禁止語ヒット 0 を事前確認済**(`grep -F` で 15 パターン)。マージ後も既存コンテンツでは緑。
- マージ = CI enforcement の有効化。レビューの上で判断してください(自動マージしていません)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
